### PR TITLE
A number of fixes

### DIFF
--- a/src/main/java/com/cloudera/whirr/cm/BaseHandlerCm.java
+++ b/src/main/java/com/cloudera/whirr/cm/BaseHandlerCm.java
@@ -32,4 +32,10 @@ public abstract class BaseHandlerCm extends BaseHandler {
     addStatement(event, call("retry_helpers"));
   }
 
+  @Override
+  protected void beforeConfigure(ClusterActionEvent event) throws IOException, InterruptedException {
+    super.beforeConfigure(event);
+    addStatement(event, call("retry_helpers"));
+  }
+
 }

--- a/src/main/java/com/cloudera/whirr/cm/BaseHandlerCm.java
+++ b/src/main/java/com/cloudera/whirr/cm/BaseHandlerCm.java
@@ -20,10 +20,21 @@ package com.cloudera.whirr.cm;
 import static org.jclouds.scriptbuilder.domain.Statements.call;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
+import org.apache.whirr.Cluster.Instance;
 import org.apache.whirr.service.ClusterActionEvent;
+import org.apache.whirr.service.hadoop.VolumeManager;
+
+import com.google.common.collect.Iterables;
 
 public abstract class BaseHandlerCm extends BaseHandler {
+
+  public static final String DATA_DIRS_ROOT = "cm.data.dirs.root";
+  public static final String DATA_DIRS_DEFAULT = "cm.data.dirs.default";
+  
+  protected Map<String,String> deviceMappings = new HashMap<String,String>();
 
   @Override
   protected void beforeBootstrap(ClusterActionEvent event) throws IOException, InterruptedException {
@@ -31,11 +42,29 @@ public abstract class BaseHandlerCm extends BaseHandler {
     addStatement(event, call("configure_hostnames"));
     addStatement(event, call("retry_helpers"));
   }
-
+  
   @Override
   protected void beforeConfigure(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeConfigure(event);
     addStatement(event, call("retry_helpers"));
+
+    if (getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_ROOT) == null) {
+      getDeviceMappings(event);
+      String devMappings = VolumeManager.asString(deviceMappings);
+      addStatement(event, call("prepare_all_disks", "'" + devMappings + "'"));
+    }
   }
 
+  public Map<String, String> getDeviceMappings(ClusterActionEvent event) {
+    if (deviceMappings.isEmpty()) {
+      Instance prototype = Iterables.getFirst(event.getCluster().getInstances(), null);
+      if (prototype == null) {
+        throw new IllegalStateException("No instances found.");
+      }
+      VolumeManager volumeManager = new VolumeManager();
+      deviceMappings.putAll(volumeManager.getDeviceMappings(event.getClusterSpec(), prototype));
+    } 
+    
+    return deviceMappings;
+  }
 }

--- a/src/main/java/com/cloudera/whirr/cm/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerHandler.java
@@ -24,6 +24,7 @@ import static org.jclouds.scriptbuilder.domain.Statements.createOrOverwriteFile;
 import java.io.IOException;
 import java.net.URL;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -178,6 +179,8 @@ public class CmServerHandler extends BaseHandlerCm {
 
         try {
 
+          BaseHandlerCmCdh.CmServerClusterSingleton.getInstance().setDataMounts(getDataMounts(event));
+          
           System.out.println();
           System.out.println("Roles:");
           BaseHandlerCmCdh.CmServerClusterSingleton.getInstance().clearServices();
@@ -312,6 +315,22 @@ public class CmServerHandler extends BaseHandlerCm {
 
     }
 
+  }
+
+  private Set<String> getDataMounts(ClusterActionEvent event) throws IOException {
+    Set<String> mnts = new HashSet<String>();
+
+    String overrideMnt = getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_ROOT);
+
+    if (overrideMnt != null) {
+      mnts.add(overrideMnt);
+    } else if (!getDeviceMappings(event).isEmpty()) {
+      mnts.addAll(getDeviceMappings(event).keySet());
+    } else {
+      mnts.add(getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_DEFAULT));
+    }
+
+    return mnts;
   }
 
 }

--- a/src/main/java/com/cloudera/whirr/cm/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerHandler.java
@@ -191,10 +191,10 @@ public class CmServerHandler extends BaseHandlerCm {
                 CmServerService service = new CmServerService(type, event.getClusterSpec().getConfiguration()
                     .getString(CONFIG_WHIRR_NAME, CM_CLUSTER_NAME), ""
                     + (BaseHandlerCmCdh.CmServerClusterSingleton.getInstance().getServices(type).size() + 1),
-                    instance.getPublicHostName());
+                    instance);
                 BaseHandlerCmCdh.CmServerClusterSingleton.getInstance().add(service);
                 System.out.println(service.getName() + "@[id=" + instance.getId() + ", ip=" + instance.getPublicIp()
-                    + ", host=" + service.getHost() + "]");
+                                   + ", host=" + service.getHost().getPublicHostName() + "]");
               }
             }
           }

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerApi.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerApi.java
@@ -30,6 +30,8 @@ import java.util.TreeSet;
 
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 
+import org.apache.whirr.Cluster.Instance;
+
 import com.cloudera.api.ClouderaManagerClientBuilder;
 import com.cloudera.api.DataView;
 import com.cloudera.api.model.ApiBulkCommandList;
@@ -53,7 +55,12 @@ import com.cloudera.api.model.ApiServiceList;
 import com.cloudera.api.v3.ParcelResource;
 import com.cloudera.api.v3.RootResourceV3;
 import com.cloudera.whirr.cm.api.CmServerApiLog.CmServerApiLogSyncCommand;
+
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 
 public class CmServerApi {
 
@@ -131,16 +138,16 @@ public class CmServerApi {
     return configPostUpdate;
   }
 
-  public Set<String> hosts() throws CmServerApiException {
+  public Set<ApiHost> hosts() throws CmServerApiException {
 
-    final Set<String> hosts = new HashSet<String>();
+    final Set<ApiHost> hosts = new HashSet<ApiHost>();
     try {
 
       logger.logOperation("GetHosts", new CmServerApiLogSyncCommand() {
         @Override
         public void execute() {
           for (ApiHost host : apiResourceRoot.getHostsResource().readHosts(DataView.SUMMARY).getHosts()) {
-            hosts.add(host.getHostId());
+            hosts.add(host);
           }
         }
       });
@@ -332,8 +339,8 @@ public class CmServerApi {
     });
 
     List<ApiHostRef> apiHostRefs = Lists.newArrayList();
-    for (String host : hosts()) {
-      apiHostRefs.add(new ApiHostRef(host));
+    for (ApiHost host : hosts()) {
+      apiHostRefs.add(new ApiHostRef(host.getHostId()));
     }
     apiResourceRoot.getClustersResource().addHosts(getName(cluster), new ApiHostRefList(apiHostRefs));
 
@@ -399,7 +406,7 @@ public class CmServerApi {
 
   }
 
-  private void configureServices(final CmServerCluster cluster) throws IOException, InterruptedException {
+  private void configureServices(final CmServerCluster cluster) throws IOException, InterruptedException, CmServerApiException {
 
     final ApiServiceList serviceList = new ApiServiceList();
     for (CmServerServiceType type : cluster.getServiceTypes()) {
@@ -439,7 +446,7 @@ public class CmServerApi {
 
   }
 
-  private ApiService buildServices(final CmServerCluster cluster, CmServerServiceType type) throws IOException {
+  private ApiService buildServices(final CmServerCluster cluster, CmServerServiceType type) throws IOException, CmServerApiException {
 
     ApiService apiService = new ApiService();
     List<ApiRole> apiRoles = new ArrayList<ApiRole>();
@@ -510,10 +517,11 @@ public class CmServerApi {
     }
 
     for (CmServerService subService : cluster.getServices(type)) {
+      String hostId = getHostIdForInstance(subService.getHost());
       ApiRole apiRole = new ApiRole();
       apiRole.setName(subService.getName());
       apiRole.setType(subService.getType().getLabel());
-      apiRole.setHostRef(new ApiHostRef(subService.getHost()));
+      apiRole.setHostRef(new ApiHostRef(hostId));
       apiRole.setRoleConfigGroupRef(new ApiRoleConfigGroupRef(subService.getGroup()));
       apiRoles.add(apiRole);
     }
@@ -524,6 +532,31 @@ public class CmServerApi {
     return apiService;
   }
 
+  private String getHostIdForInstance(Instance instance) throws IOException, CmServerApiException {
+    String hostId;
+    Set<ApiHost> hosts = hosts();
+
+    final String hostName = instance.getPublicHostName();
+    final String privateIp = instance.getPrivateIp();
+    final String publicIp = instance.getPublicIp();
+    ApiHost actualHost = Iterables.getOnlyElement(Sets.filter(hosts, new Predicate<ApiHost>() {
+          @Override
+          public boolean apply(ApiHost host) {
+            return host.getHostname().equals(hostName)
+            || host.getIpAddress().equals(privateIp)
+            || host.getIpAddress().equals(publicIp);
+          }
+        }), null);
+
+    if (actualHost != null) {
+      hostId = actualHost.getHostId();
+    } else {
+      hostId = "";
+    }
+
+    return hostId;
+  }
+  
   private void initPreStartServices(final CmServerCluster cluster, CmServerServiceType type) throws IOException,
       InterruptedException {
 

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerApi.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerApi.java
@@ -484,19 +484,19 @@ public class CmServerApi {
       // TODO Refactor, dont hardcode, pass through from whirr config
       switch (subType) {
       case HDFS_NAMENODE:
-        apiConfigList.add(new ApiConfig("dfs_name_dir_list", "/data/1/dfs/nn"));
+        apiConfigList.add(new ApiConfig("dfs_name_dir_list", cluster.getDataDirsForSuffix("/dfs/nn")));
         break;
       case HDFS_SECONDARY_NAMENODE:
-        apiConfigList.add(new ApiConfig("fs_checkpoint_dir_list", "/data/1/dfs/snn"));
+        apiConfigList.add(new ApiConfig("fs_checkpoint_dir_list", cluster.getDataDirsForSuffix("/dfs/snn")));
         break;
       case HDFS_DATANODE:
-        apiConfigList.add(new ApiConfig("dfs_data_dir_list", "/mnt/data/1/dfs/dn"));
+        apiConfigList.add(new ApiConfig("dfs_data_dir_list", cluster.getDataDirsForSuffix("/dfs/dn")));
         break;
       case MAPREDUCE_JOB_TRACKER:
-        apiConfigList.add(new ApiConfig("jobtracker_mapred_local_dir_list", "/data/1/mapred/jt"));
+        apiConfigList.add(new ApiConfig("jobtracker_mapred_local_dir_list", cluster.getDataDirsForSuffix("/mapred/jt")));
         break;
       case MAPREDUCE_TASK_TRACKER:
-        apiConfigList.add(new ApiConfig("tasktracker_mapred_local_dir_list", "/data/1/mapred/local"));
+        apiConfigList.add(new ApiConfig("tasktracker_mapred_local_dir_list", cluster.getDataDirsForSuffix("/mapred/local")));
         break;
       default:
         break;

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerCluster.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerCluster.java
@@ -26,8 +26,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+
 public class CmServerCluster {
 
+  private Set<String> dataMounts = new HashSet<String>();
+  
   private Map<CmServerServiceType, List<CmServerService>> services = new HashMap<CmServerServiceType, List<CmServerService>>();
 
   public CmServerCluster() {
@@ -160,6 +167,24 @@ public class CmServerCluster {
     return hosts;
   }
 
+  public synchronized void setDataMounts(Set<String> mnts) {
+    this.dataMounts.addAll(mnts);
+  }
+
+  public synchronized Set<String> getDataMounts() {
+    return ImmutableSet.copyOf(dataMounts);
+  }
+
+  public String getDataDirsForSuffix(final String suffix) throws IOException {
+    return Joiner.on(',').join(Lists.transform(Lists.newArrayList(getDataMounts()),
+      new Function<String, String>() {
+        @Override public String apply(String input) {
+          return input + suffix;
+        }
+      }
+    ));
+  }
+  
   private void assertConsistentTopology(CmServerServiceType type) throws CmServerApiException {
     if (type.getParent() == null || type.getParent().getParent() == null) {
       throw new CmServerApiException("Invalid cluster topology: Attempt to add non leaf type [" + type + "]");

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerCluster.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerCluster.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.whirr.Cluster.Instance;
+
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
@@ -145,8 +147,8 @@ public class CmServerCluster {
     throw new IOException("Cannot determine service name, cluster is empty");
   }
 
-  public synchronized Set<String> getServiceHosts(CmServerServiceType type) {
-    Set<String> hosts = new HashSet<String>();
+  public synchronized Set<Instance> getServiceHosts(CmServerServiceType type) {
+    Set<Instance> hosts = new HashSet<Instance>();
     if (type.equals(CmServerServiceType.CLUSTER)) {
       for (CmServerServiceType serviceType : services.keySet()) {
         for (CmServerService service : services.get(serviceType)) {

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerService.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerService.java
@@ -17,6 +17,8 @@
  */
 package com.cloudera.whirr.cm.api;
 
+import org.apache.whirr.Cluster.Instance;
+
 public class CmServerService {
 
   public static final String NAME_TOKEN_DELIM = "_";
@@ -28,17 +30,17 @@ public class CmServerService {
   private CmServerServiceType type;
   private String tag;
   private String qualifier;
-  private String host;
+  private Instance host;
 
   public CmServerService(CmServerServiceType type) {
-    this(type, "", "1", "");
+    this(type, "", "1", null);
   }
 
   public CmServerService(CmServerServiceType type, String tag) {
-    this(type, tag, "1", "");
+    this(type, tag, "1", null);
   }
 
-  public CmServerService(CmServerServiceType type, String tag, String qualifier, String host) {
+  public CmServerService(CmServerServiceType type, String tag, String qualifier, Instance host) {
     this.name = tag + (tag.equals("") ? "" : NAME_TOKEN_DELIM) + type.toString().toLowerCase() + NAME_TOKEN_DELIM
         + qualifier;
     this.group = tag + (tag.equals("") ? "" : NAME_TOKEN_DELIM) + type.toString().toLowerCase() + NAME_TOKEN_DELIM
@@ -102,7 +104,7 @@ public class CmServerService {
     return qualifier;
   }
 
-  public String getHost() {
+  public Instance getHost() {
     return host;
   }
 

--- a/src/main/resources/functions/install_cmcdh_hivemetastore.sh
+++ b/src/main/resources/functions/install_cmcdh_hivemetastore.sh
@@ -21,10 +21,11 @@ function install_cmcdh_hivemetastore() {
   if which dpkg &> /dev/null; then
     export DEBIAN_FRONTEND=noninteractive
     retry_apt_get update
-    retry_apt_get -q -y mysql-server libmysql-java
+    retry_apt_get -q -y install mysql-server-5.5 mysql-client-5.5 libmysql-java
+    service mysql start
   elif which rpm &> /dev/null; then
     retry_yum install -y mysql-server mysql-connector-java
+    service mysqld start
+    chkconfig mysqld on
   fi
-  service mysqld start
-  chkconfig mysqld on
 }

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -20,3 +20,4 @@ cmserver.port.comms=7182
 cmserver.ports=
 cmnode.ports=8088,8888,50030,50060,50070,50090,60010,60030
 
+cm.data.dirs.default=/data/1

--- a/src/test/java/com/cloudera/whirr/cm/api/CmServerClusterTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/api/CmServerClusterTest.java
@@ -19,11 +19,17 @@ package com.cloudera.whirr.cm.api;
 
 import java.io.IOException;
 
+import org.apache.whirr.Cluster.Instance;
+
+import org.jclouds.domain.Credentials;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.cloudera.whirr.cm.BaseTest;
+
+import com.google.common.collect.Sets;
 
 public class CmServerClusterTest implements BaseTest {
 
@@ -31,17 +37,33 @@ public class CmServerClusterTest implements BaseTest {
 
   private CmServerCluster cluster;
 
+  private Credentials credentials;
+  private Instance host1;
+  private Instance host2;
+  private Instance host3;
+  private Instance host4;
+
   @Before
   public void setupCluster() throws CmServerApiException {
+    credentials = new Credentials("dummy", "dummy");
+    host1 = new Instance(credentials, Sets.newHashSet("role1", "role2"), "127.0.0.1",
+                         "127.0.0.1", "i-host1", null);
+    host2 = new Instance(credentials, Sets.newHashSet("role1", "role2"), "127.0.0.2",
+                         "127.0.0.2", "i-host2", null);
+    host3 = new Instance(credentials, Sets.newHashSet("role1", "role2"), "127.0.0.3",
+                         "127.0.0.3", "i-host3", null);
+    host4 = new Instance(credentials, Sets.newHashSet("role1", "role2"), "127.0.0.4",
+                         "127.0.0.4", "i-host4", null);
+    
     cluster = new CmServerCluster();
-    cluster.add(new CmServerService(CmServerServiceType.HDFS_DATANODE, CLUSTER_TAG, "2", "host-2"));
-    cluster.add(new CmServerService(CmServerServiceType.HDFS_NAMENODE, CLUSTER_TAG, "1", "host-1"));
-    cluster.add(new CmServerService(CmServerServiceType.HDFS_DATANODE, CLUSTER_TAG, "1", "host-1"));
-    cluster.add(new CmServerService(CmServerServiceType.HDFS_SECONDARY_NAMENODE, CLUSTER_TAG, "1", "host-1"));
-    cluster.add(new CmServerService(CmServerServiceType.HDFS_DATANODE, CLUSTER_TAG, "3", "host-3"));
-    cluster.add(new CmServerService(CmServerServiceType.HDFS_DATANODE, CLUSTER_TAG, "4", "host-4"));
-    cluster.add(new CmServerService(CmServerServiceType.HBASE_REGIONSERVER, CLUSTER_TAG, "1", "host-4"));
-    cluster.add(new CmServerService(CmServerServiceType.IMPALA_DAEMON, CLUSTER_TAG, "1", "host-4"));
+    cluster.add(new CmServerService(CmServerServiceType.HDFS_DATANODE, CLUSTER_TAG, "2", host2));
+    cluster.add(new CmServerService(CmServerServiceType.HDFS_NAMENODE, CLUSTER_TAG, "1", host1));
+    cluster.add(new CmServerService(CmServerServiceType.HDFS_DATANODE, CLUSTER_TAG, "1", host1));
+    cluster.add(new CmServerService(CmServerServiceType.HDFS_SECONDARY_NAMENODE, CLUSTER_TAG, "1", host1));
+    cluster.add(new CmServerService(CmServerServiceType.HDFS_DATANODE, CLUSTER_TAG, "3", host3));
+    cluster.add(new CmServerService(CmServerServiceType.HDFS_DATANODE, CLUSTER_TAG, "4", host4));
+    cluster.add(new CmServerService(CmServerServiceType.HBASE_REGIONSERVER, CLUSTER_TAG, "1", host4));
+    cluster.add(new CmServerService(CmServerServiceType.IMPALA_DAEMON, CLUSTER_TAG, "1", host4));
   }
 
   @Test
@@ -54,7 +76,7 @@ public class CmServerClusterTest implements BaseTest {
     cluster.add(CmServerServiceType.HDFS_NAMENODE);
     Assert.assertFalse(cluster.isEmpty());
     Assert.assertTrue(cluster.isEmptyServices());
-    cluster.add(new CmServerService(CmServerServiceType.HDFS_NAMENODE, CLUSTER_TAG, "1", "host-1"));
+    cluster.add(new CmServerService(CmServerServiceType.HDFS_NAMENODE, CLUSTER_TAG, "1", host1));
     Assert.assertFalse(cluster.isEmpty());
     Assert.assertFalse(cluster.isEmptyServices());
     cluster.clearServices();


### PR DESCRIPTION
Currently:
- Hive Metastore db setup fixed on Ubuntu 12.04
- expect installation fixed by adding retry_helpers to configure phase
- Data disk detection/utilization, with fallbacks to original stuff by default
- Better filtering/mapping of Whirr Cluster.Instances to CM ApiHosts to deal with non-matching hostnames, etc.
