### PR TITLE
Add CDH-from-packages option and flume agent

### DIFF
--- a/src/main/java/com/cloudera/whirr/cm/BaseHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/BaseHandler.java
@@ -29,6 +29,7 @@ public abstract class BaseHandler extends ClusterActionHandlerSupport {
 
   public static final String CONFIG_WHIRR_NAME = "whirr.cluster-name";
   public static final String CONFIG_WHIRR_AUTO_VARIABLE = "whirr.env.cmauto";
+  public static final String CONFIG_WHIRR_USE_PACKAGES = "whirr.cm.use.packages";
   public static final String CONFIG_WHIRR_CM_PREFIX = "whirr.cm.config.";
 
   public static final String CM_CLUSTER_NAME = "whirr";

--- a/src/main/java/com/cloudera/whirr/cm/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerHandler.java
@@ -155,6 +155,12 @@ public class CmServerHandler extends BaseHandlerCm {
 
         try {
 
+          if (event.getClusterSpec().getConfiguration().getBoolean(CONFIG_WHIRR_USE_PACKAGES, false)) {
+            BaseHandlerCmCdh.CmServerClusterSingleton.getInstance().setIsParcel(false);
+          } else {
+            BaseHandlerCmCdh.CmServerClusterSingleton.getInstance().setIsParcel(true);
+          }
+          
           BaseHandlerCmCdh.CmServerClusterSingleton.getInstance().setDataMounts(getDataMounts(event));
 
           logLineItem("Roles:");

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerApiImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerApiImpl.java
@@ -759,6 +759,9 @@ public class CmServerApiImpl implements CmServerApi {
       apiServiceConfig.add(new ApiConfig("hbase_service", cluster.getServiceName(CmServerServiceType.HBASE)));
       apiServiceConfig.add(new ApiConfig("hive_service", cluster.getServiceName(CmServerServiceType.HIVE)));
       break;
+    case FLUME:
+      apiServiceConfig.add(new ApiConfig("hdfs_service", cluster.getServiceName(CmServerServiceType.HDFS)));
+      apiServiceConfig.add(new ApiConfig("hbase_service", cluster.getServiceName(CmServerServiceType.HBASE)));
     default:
       break;
     }

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerApiImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerApiImpl.java
@@ -407,7 +407,9 @@ public class CmServerApiImpl implements CmServerApi {
 
       if (!isProvisioned(cluster)) {
         provsionCluster(cluster);
-        provisionParcels(cluster);
+        if (cluster.getIsParcel()) {
+          provisionParcels(cluster);
+        }
         executed = true;
       }
 

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerCluster.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerCluster.java
@@ -35,6 +35,8 @@ public class CmServerCluster {
 
   private Set<String> dataMounts = new HashSet<String>();
 
+  private boolean isParcel = true;
+  
   public CmServerCluster() {
   }
 
@@ -163,6 +165,14 @@ public class CmServerCluster {
             }));
   }
 
+  public void setIsParcel(boolean isParcel) {
+    this.isParcel = isParcel;
+  }
+
+  public boolean getIsParcel() {
+    return isParcel;
+  }
+    
   private void assertConsistentTopology(CmServerServiceType type) throws CmServerApiException {
     if (type.getParent() == null || type.getParent().getParent() == null) {
       throw new CmServerApiException("Invalid cluster topology: Attempt to add non leaf type [" + type + "]");

--- a/src/main/java/com/cloudera/whirr/cm/api/CmServerServiceType.java
+++ b/src/main/java/com/cloudera/whirr/cm/api/CmServerServiceType.java
@@ -60,6 +60,9 @@ public enum CmServerServiceType {
   IMPALA(CLUSTER, "IMPALA", CmServerServiceTypeRepository.IMPALA), IMPALA_STATE_STORE(IMPALA, "STATESTORE",
       CmServerServiceTypeRepository.IMPALA), IMPALA_DAEMON(IMPALA, "IMPALAD", CmServerServiceTypeRepository.IMPALA),
 
+  // Flume
+  FLUME(CLUSTER, "FLUME", CmServerServiceTypeRepository.CDH), FLUME_AGENT(FLUME, "AGENT", CmServerServiceTypeRepository.CDH),
+
   // Client
   CLIENT(CLUSTER, "GATEWAY", CmServerServiceTypeRepository.CDH);
 

--- a/src/main/java/com/cloudera/whirr/cm/cdh/BaseHandlerCmCdh.java
+++ b/src/main/java/com/cloudera/whirr/cm/cdh/BaseHandlerCmCdh.java
@@ -18,6 +18,7 @@
 package com.cloudera.whirr.cm.cdh;
 
 import static org.apache.whirr.RolePredicates.role;
+import static org.jclouds.scriptbuilder.domain.Statements.call;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -54,6 +55,11 @@ public abstract class BaseHandlerCmCdh extends BaseHandler {
       throw new IOException(e);
     }
     roleToType.putIfAbsent(getRole(), getType());
+
+    if (event.getClusterSpec().getConfiguration().getBoolean(CONFIG_WHIRR_USE_PACKAGES, false)) {
+      addStatement(event, call("register_cdh_repo"));
+      addStatement(event, call("install_cdh_packages"));
+    }
   }
 
   @Override

--- a/src/main/java/com/cloudera/whirr/cm/cdh/CmCdhFlumeAgentHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/cdh/CmCdhFlumeAgentHandler.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.whirr.cm.cdh;
+
+import com.cloudera.whirr.cm.api.CmServerServiceType;
+
+public class CmCdhFlumeAgentHandler extends BaseHandlerCmCdh {
+
+  public static final String ROLE = "cm-cdh-flume-agent";
+  public static final CmServerServiceType TYPE = CmServerServiceType.FLUME_AGENT;
+
+  @Override
+  public String getRole() {
+    return ROLE;
+  }
+
+  @Override
+  public CmServerServiceType getType() {
+    return TYPE;
+  }
+
+}

--- a/src/main/resources/META-INF/services/org.apache.whirr.service.ClusterActionHandler
+++ b/src/main/resources/META-INF/services/org.apache.whirr.service.ClusterActionHandler
@@ -42,3 +42,5 @@ com.cloudera.whirr.cm.cdh.CmCdhHueServerHandler
 com.cloudera.whirr.cm.cdh.CmCdhHueBeeswaxServerHandler
 
 com.cloudera.whirr.cm.cdh.CmCdhOozieServerHandler
+
+com.cloudera.whirr.cm.cdh.CmCdhFlumeAgentHandler

--- a/src/main/resources/functions/install_cdh_packages.sh
+++ b/src/main/resources/functions/install_cdh_packages.sh
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -x
+
+function install_cdh_packages() {
+    if which dpkg &> /dev/null; then
+        retry_apt_get -y install bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper hue sqoop
+        if ls /etc/init.d/hadoop-* &> /dev/null; then
+            for SERVICE_SCRIPT in /etc/init.d/hadoop-*; do
+                service $(basename $SERVICE_SCRIPT) stop
+                update-rc.d -f $(basename $SERVICE_SCRIPT) remove
+            done
+        fi
+        service hue stop
+        update-rc.d -f hue remove
+        service oozie stop
+        update-rc.d -f oozie remove
+    elif which rpm &> /dev/null; then
+        retry_yum install -y bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper impala impala-shell hue sqoop
+        if ls /etc/init.d/hadoop-* &> /dev/null; then
+            for SERVICE_SCRIPT in /etc/init.d/hadoop-*; do
+                service $(basename $SERVICE_SCRIPT) stop
+                chkconfig $(basename $SERVICE_SCRIPT) off
+            done
+        fi
+        service hue stop
+        chkconfig hue off
+        service oozie stop
+        chkconfig oozie off    
+    fi
+}

--- a/src/main/resources/functions/install_cdh_packages.sh
+++ b/src/main/resources/functions/install_cdh_packages.sh
@@ -18,7 +18,7 @@ set -x
 
 function install_cdh_packages() {
     if which dpkg &> /dev/null; then
-        retry_apt_get -y install bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper hue sqoop
+        retry_apt_get -y install bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper hue sqoop flume-ng flume-ng-agent
         if ls /etc/init.d/hadoop-* &> /dev/null; then
             for SERVICE_SCRIPT in /etc/init.d/hadoop-*; do
                 service $(basename $SERVICE_SCRIPT) stop
@@ -27,10 +27,12 @@ function install_cdh_packages() {
         fi
         service hue stop
         update-rc.d -f hue remove
+        service flume-ng-agent stop
+        update-rc.d -f flume-ng-agent remove
         service oozie stop
         update-rc.d -f oozie remove
     elif which rpm &> /dev/null; then
-        retry_yum install -y bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper impala impala-shell hue sqoop
+        retry_yum install -y bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper impala impala-shell hue sqoop flume-ng flume-ng-agent
         if ls /etc/init.d/hadoop-* &> /dev/null; then
             for SERVICE_SCRIPT in /etc/init.d/hadoop-*; do
                 service $(basename $SERVICE_SCRIPT) stop
@@ -39,6 +41,8 @@ function install_cdh_packages() {
         fi
         service hue stop
         chkconfig hue off
+        service flume-ng-agent stop
+        chkconfig flume-ng-agent off
         service oozie stop
         chkconfig oozie off    
     fi

--- a/src/main/resources/functions/install_cm.sh
+++ b/src/main/resources/functions/install_cm.sh
@@ -18,28 +18,28 @@
 set -x
 
 function install_cm() {
-  REPO=${REPOCM:-cm4}
-  REPO_HOST=${REPO_HOST:-archive.cloudera.com}
-  CM_MAJOR_VERSION=$(echo $REPO | sed -e 's/cm\([0-9]\).*/\1/')
-  CM_VERSION=$(echo $REPO | sed -e 's/cm\([0-9][0-9]*\)/\1/')
+  REPOCM=${REPOCM:-cm4}
+  CM_REPO_HOST=${CM_REPO_HOST:-archive.cloudera.com}
+  CM_MAJOR_VERSION=$(echo $REPOCM | sed -e 's/cm\([0-9]\).*/\1/')
+  CM_VERSION=$(echo $REPOCM | sed -e 's/cm\([0-9][0-9]*\)/\1/')
   OS_CODENAME=$(lsb_release -sc)
   OS_DISTID=$(lsb_release -si | tr '[A-Z]' '[a-z]')
   if [ $CM_MAJOR_VERSION -ge 4 ]; then
 	  if which dpkg &> /dev/null; then
-        cat > /etc/apt/sources.list.d/cloudera-$REPO.list <<EOF
-deb [arch=amd64] http://$REPO_HOST/cm$CM_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cm $OS_CODENAME-$REPO contrib
-deb-src http://$REPO_HOST/cm$CM_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cm $OS_CODENAME-$REPO contrib
+        cat > /etc/apt/sources.list.d/cloudera-$REPOCM.list <<EOF
+deb [arch=amd64] http://$CM_REPO_HOST/cm$CM_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cm $OS_CODENAME-$REPOCM contrib
+deb-src http://$CM_REPO_HOST/cm$CM_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cm $OS_CODENAME-$REPOCM contrib
 EOF
-        curl -s http://$REPO_HOST/cm$CM_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cm/archive.key | apt-key add -
+        curl -s http://$CM_REPO_HOST/cm$CM_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cm/archive.key | apt-key add -
 	  elif which rpm &> /dev/null; then
-        cat > /etc/yum.repos.d/cloudera-$REPO.repo <<EOF
-[cloudera-manager-$REPO]
+        cat > /etc/yum.repos.d/cloudera-$REPOCM.repo <<EOF
+[cloudera-manager-$REPOCM]
 name=Cloudera Manager, Version $CM_VERSION
-baseurl=http://$REPO_HOST/cm$CM_MAJOR_VERSION/redhat/\$releasever/\$basearch/cm/$CM_VERSION/
-gpgkey=http://$REPO_HOST/cm$CM_MAJOR_VERSION/redhat/\$releasever/\$basearch/cm/RPM-GPG-KEY-cloudera
+baseurl=http://$CM_REPO_HOST/cm$CM_MAJOR_VERSION/redhat/\$releasever/\$basearch/cm/$CM_VERSION/
+gpgkey=http://$CM_REPO_HOST/cm$CM_MAJOR_VERSION/redhat/\$releasever/\$basearch/cm/RPM-GPG-KEY-cloudera
 gpgcheck=1
 EOF
-        rpm --import http://$REPO_HOST/cm$CM_MAJOR_VERSION/redhat/$(rpm -q --qf "%{VERSION}" $(rpm -q --whatprovides redhat-release))/$(rpm -q --qf "%{ARCH}" $(rpm -q --whatprovides redhat-release))/cm/RPM-GPG-KEY-cloudera
+        rpm --import http://$CM_REPO_HOST/cm$CM_MAJOR_VERSION/redhat/$(rpm -q --qf "%{VERSION}" $(rpm -q --whatprovides redhat-release))/$(rpm -q --qf "%{ARCH}" $(rpm -q --whatprovides redhat-release))/cm/RPM-GPG-KEY-cloudera
 	  fi
   fi
 }

--- a/src/main/resources/functions/register_cdh_repo.sh
+++ b/src/main/resources/functions/register_cdh_repo.sh
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -x
+function register_cdh_repo() {
+    REPOCDH=${REPOCDH:-cdh4}
+    CDH_REPO_HOST=${CDH_REPO_HOST:-archive.cloudera.com}
+    CDH_MAJOR_VERSION=$(echo $REPOCDH | sed -e 's/cdh\([0-9]\).*/\1/')
+    CDH_VERSION=$(echo $REPOCDH | sed -e 's/cdh\([0-9][0-9]*\)/\1/')
+    if which dpkg &> /dev/null; then
+	retry_apt-get -y install lsb-release
+	OS_CODENAME=$(lsb_release -sc)
+	OS_DISTID=$(lsb_release -si | tr '[A-Z]' '[a-z]')
+        cat > /etc/apt/sources.list.d/cloudera-$REPOCDH.list <<EOF
+deb [arch=amd64] http://$CDH_REPO_HOST/cdh$CDH_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cdh $OS_CODENAME-$REPOCDH contrib
+deb-src http://$CDH_REPO_HOST/cdh$CDH_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cdh $OS_CODENAME-$REPOCDH contrib
+EOF
+        curl -s http://$CDH_REPO_HOST/cdh$CDH_MAJOR_VERSION/$OS_DISTID/$OS_CODENAME/amd64/cdh/archive.key | apt-key add -
+        retry_apt_get -y update
+    elif which rpm &> /dev/null; then
+        cat > /etc/yum.repos.d/cloudera-$REPOCDH.repo <<EOF
+[cloudera-$REPOCDH]
+name=Cloudera's Distribution for Hadoop, Version $CDH_VERSION
+baseurl=http://$CDH_REPO_HOST/cdh$CDH_MAJOR_VERSION/redhat/\$releasever/\$basearch/cdh/$CDH_VERSION/
+gpgkey=http://$CDH_REPO_HOST/cdh$CDH_MAJOR_VERSION/redhat/\$releasever/\$basearch/cdh/RPM-GPG-KEY-cloudera
+gpgcheck=1
+EOF
+        rpm --import http://$CDH_REPO_HOST/cdh$CDH_MAJOR_VERSION/redhat/$(rpm -q --qf "%{VERSION}" $(rpm -q --whatprovides redhat-release))/$(rpm -q --qf "%{ARCH}" $(rpm -q --whatprovides redhat-release))/cdh/RPM-GPG-KEY-cloudera
+        
+        retry_yum update -y retry_yum
+    fi
+}


### PR DESCRIPTION
If whirr.cm.use.packages=true is specified, CDH packages will be installed (except for impala - that's still separate, but I'm holding off on that until it's got a permanent repo location on archive.cloudera.com rather than beta.cloudera.com) and parcels won't be.

Also added flume agent handler and related handwaving magic. =)
