### PR TITLE
CDH-11359: Provide whirr-cm interactive command implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mvn clean install -Dmaven.test.skip=true
 cp -rvf target/whirr-cm-*.jar $WHIRR_HOME/lib
 ```
 
-## Get your Whirr Cloudera Manager CDH cluster configuration
+## Launch a Cloudera Manager Cluster
 
 A sample Whirr CM CDH EC2 config is available here: 
 
@@ -58,8 +58,6 @@ have one), place the license in a file "cm-license.txt" on the whirr classpath (
 ```bash
 mv -v eval_acme_20120925_cloudera_enterprise_license.txt $WHIRR_HOME/conf/cm-license.txt
 ```
-
-## Launch a Cloudera Manager Cluster
 
 The following command will start a cluster with 4 nodes, 1 master and 3 slave nodes. To change the
 cluster topology, edit the cm-ec2.properties file.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ export AWS_SECRET_ACCESS_KEY=...
 
 Install CDH repositotries, eg for CDH4:
 
-https://ccp.cloudera.com/display/CDH4DOC/CDH4+Installation#CDH4Installation-InstallingCDH4
+http://www.cloudera.com/content/support/en/documentation/cdh4-documentation/cdh4-documentation-v4-latest.html#CDH4Installation-InstallingCDH4
 
 then install the whirr package and create some environment variables, eg for RHEL/CentOS:
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,7 @@
 # Launching Cloudera Manager with Whirr
 
-Follow these instructions to start a cluster on EC2 running Cloudera Manager.
-Cloudera Manager allows you to install, run, and manage a Hadoop cluster.
-
-This method uses Whirr to start a cluster with
- * one node running the Cloudera Manager Admin Console, and
- * a user-selectable number of nodes for the Hadoop cluster itself
-
-Once Whirr has started the cluster, you use Cloudera Manager in the usual way.
-
-Note that you can omit the CDH client node if you want to run programs entirely
-from Hue.
-
-It is not currently possible to launch Hadoop programs from your local machine
-that use the cluster, due to the way Cloudera Manager manages host addresses.
-To work around this limitation you can add a Gateway role which installs CDH
-client components on a node in the cloud to run programs from.
+Follow these instructions to start a cluster on EC2 running Cloudera Manager (CM),
+allowing you to install, run and manage a CDH cluster.
 
 ## Install Whirr
 
@@ -47,9 +33,9 @@ export PATH=$WHIRR_HOME/bin:$PATH
 ssh-keygen -t rsa -P '' -f ~/.ssh/id_rsa_cm
 ```
 
-## Install the Whirr Cloudera Manager Service Plugin
+## Install the Whirr Cloudera Manager Plugin
 
-Download the Whirr CM plugun source, build and install into the lib directory of your Whirr installation.
+Download the Whirr CM plugin source, build and install into the lib directory of your Whirr installation.
 
 ```bash
 git clone https://github.com/cloudera/whirr-cm.git
@@ -58,9 +44,9 @@ mvn clean install -Dmaven.test.skip=true
 cp -rvf target/whirr-cm-*.jar $WHIRR_HOME/lib
 ```
 
-## Get your whirr-cm configuration
+## Get your Whirr Cloudera Manager CDH cluster configuration
 
-A sample Whirr EC2 CM config is available here: 
+A sample Whirr CM CDH EC2 config is available here: 
 
 ```bash
 curl -O https://raw.github.com/cloudera/whirr-cm/master/cm-ec2.properties
@@ -75,43 +61,127 @@ mv -v eval_acme_20120925_cloudera_enterprise_license.txt $WHIRR_HOME/conf/cm-lic
 
 ## Launch a Cloudera Manager Cluster
 
-The following command will start a cluster with 5 Hadoop nodes. To change this
-number edit the cm-ec2.properties file. Edit the same file if you don't want to
-launch a CDH client node.
+The following command will start a cluster with 4 nodes - 1 master and 3 slave nodes. To change the
+cluster topology, edit the cm-ec2.properties file.
 
 ```bash
 whirr launch-cluster --config cm-ec2.properties
 ```
 
-Whirr will report progress to the console as it runs. The command will exit when
-the cluster is ready to be used.
+Whirr will report progress to the console as it runs and will exit once complete.
 
-## Configure the Hadoop cluster
-
-The next step is to run the Cloudera Manager Admin Console -- at the URL printed
-by the Whirr command -- to install and configure Hadoop, using the instructions
-at
-
-https://ccp.cloudera.com/display/FREE4DOC/Automated+Installation+of+Cloudera+Manager+and+CDH
-
-The output of the Whirr command includes settings for the cluster hosts
-and the authentication method to be used while running the Cloudera Manager
-Admin Console.
-
-## Use the cluster
-
-Once the Hadoop cluster is up and running you can use it via Hue (the URL
-is printed by the launch cluster command), or from a CDH gateway machine. In
-the latter case, follow these instructions to add a gateway role
-
-https://ccp.cloudera.com/display/FREE4DOC/Adding+Role+Instances
-
-Then SSH to the gateway machine. Now you can interact with the cluster,
-e.g. to list files in HDFS:
+During the various phases of execution, the Whirr CM plugin will report the CM Web Console URL, eg pre-provision
 
 ```bash
-hadoop fs -ls /tmp
+Whirr Handler -----------------------------------------------------------------
+Whirr Handler [CMClusterProvision] 
+Whirr Handler -----------------------------------------------------------------
+Whirr Handler 
+Whirr Handler [CMClusterProvision] follow live at http://37.188.114.234:7180
 ```
+
+and post-provision:
+
+```bash
+Whirr Handler [CMClusterProvision] CM SERVER
+Whirr Handler [CMClusterProvision]   http://37.188.114.234:7180
+Whirr Handler [CMClusterProvision]   ssh -o StrictHostKeyChecking=no -i /root/.ssh/whirr whirr@37.188.114.234
+```
+
+You are able to log into the CM Web Console at any stage and observe proceedings.
+
+The default admin user credentials are: 
+
+```bash
+Username: admin 
+Password: admin 
+```
+
+## Manage the CDH cluster with CM
+
+The Whirr property 'whirr.env.cmauto', as set in cm-ec2.properties:
+
+```bash
+# Switch to enable/disable the automatic setup of a cluster within Cloudera Manager,
+# its initialization and launch, defaults to true
+whirr.env.cmauto=true
+```
+
+determines whether Whirr CM plugin provisions, initilialises and starts a new CDH cluster (true)
+or merely provisions the CM Server and Agents to allow manual CDH cluster management through
+the CM Web Console (false).
+
+In either case, once Whirr has completed, the CM infrastructure will be deployed and ready to
+use, fully documented here:
+
+http://www.cloudera.com/content/support/en/documentation/manager-enterprise/cloudera-manager-enterprise-v4-latest.html
+
+You can have Whirr report the currently running cluster nodes at any time:
+
+```bash
+whirr list-cluster --config cm-ec2.properties
+```
+
+or query the Whirr CM plugin services:
+
+```bash
+whirr list-services --config cm-ec2.properties
+```
+
+As well as listing services via the 'list-services' command, the Whirr CM plugin supports the
+following commands:
+
+* download-config 
+* create-services
+* start-services
+* restart-services
+* stop-services
+* destroy-services
+* clean-cluster
+
+Where appropriate, these commands can be filtered by role via the '--roles' command line switch,
+bearing in mind that 'cm-server' is a mandatory role (all operations require it) and all lifecycle
+commands operate on the service parent of the role to ensure consistency. For example, to issue
+a HDFS service start:
+
+```bash
+whirr start-services --roles cm-server,cm-cdh-datanode --config cm-ec2.properties
+```
+
+A custom CM cluster name can be provided to most of the commands via the '--cm-cluster-name' switch.
+For example, to clean the "My Cluster" from CM:
+
+```bash
+whirr clean-cluster --cm-cluster-name "My Cluster" --config cm-ec2.properties
+```
+
+Full command documentation is available as part of Whirr:
+
+```bash
+whirr
+whirr help clean-cluster
+```
+
+## Use the CDH cluster
+
+The host you have run Whirr from can be used as a CDH client, as long as it can see the cluster 
+nodes (host,forward/reverse DNS) and has the same version of CDH installed (although not necessarily
+via the same means, eg parcels/RPMs/.debs etc).
+
+To download the CDH cluster client config to the whirr cluster working directory ($HOME/.whirr/whirr)
+
+```bash
+whirr download-config --config cm-ec2.properties
+```
+
+This will then allow the CDH clients to be executed, for example to list files in HDFS root dir:
+
+```bash
+hadoop --config $HOME/.whirr/whirr fs -ls /
+```
+
+Alternatively, you can interact with the cluster via a gateway node from within your cluster.
+
 
 ## Shutdown the cluster
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ Whirr Handler [CMClusterProvision] follow live at http://37.188.114.234:7180
 and post-provision:
 
 ```bash
+Whirr Handler [CMClusterProvision] CM AGENTS
+Whirr Handler [CMClusterProvision]   ssh -o StrictHostKeyChecking=no -i /root/.ssh/whirr whirr@37.188.114.209
+Whirr Handler [CMClusterProvision]   ssh -o StrictHostKeyChecking=no -i /root/.ssh/whirr whirr@37.188.114.210
+Whirr Handler [CMClusterProvision]   ssh -o StrictHostKeyChecking=no -i /root/.ssh/whirr whirr@37.188.114.225
+Whirr Handler [CMClusterProvision]   ssh -o StrictHostKeyChecking=no -i /root/.ssh/whirr whirr@37.188.114.234
 Whirr Handler [CMClusterProvision] CM SERVER
 Whirr Handler [CMClusterProvision]   http://37.188.114.234:7180
 Whirr Handler [CMClusterProvision]   ssh -o StrictHostKeyChecking=no -i /root/.ssh/whirr whirr@37.188.114.234

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Launching Cloudera Manager with Whirr
 
-Follow these instructions to start a cluster on EC2 running Cloudera Manager (CM),
+Follow these instructions to start a cluster on Amazon EC2 running Cloudera Manager (CM),
 allowing you to install, run and manage a CDH cluster.
 
 ## Install Whirr
 
 Run the following commands from you local machine.
 
-### Set your AWS credentials as environment variables:
+### Set your AWS credentials:
 ```bash
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
@@ -61,7 +61,7 @@ mv -v eval_acme_20120925_cloudera_enterprise_license.txt $WHIRR_HOME/conf/cm-lic
 
 ## Launch a Cloudera Manager Cluster
 
-The following command will start a cluster with 4 nodes - 1 master and 3 slave nodes. To change the
+The following command will start a cluster with 4 nodes, 1 master and 3 slave nodes. To change the
 cluster topology, edit the cm-ec2.properties file.
 
 ```bash
@@ -107,7 +107,7 @@ The Whirr property 'whirr.env.cmauto', as set in cm-ec2.properties:
 whirr.env.cmauto=true
 ```
 
-determines whether Whirr CM plugin provisions, initilialises and starts a new CDH cluster (true)
+determines whether the Whirr CM plugin provisions, initilialises and starts a new CDH cluster (true)
 or merely provisions the CM Server and Agents to allow manual CDH cluster management through
 the CM Web Console (false).
 
@@ -137,7 +137,9 @@ following commands:
 * restart-services
 * stop-services
 * destroy-services
+* launch-cluster
 * clean-cluster
+* destroy-cluster
 
 Where appropriate, these commands can be filtered by role via the '--roles' command line switch,
 bearing in mind that 'cm-server' is a mandatory role (all operations require it) and all lifecycle

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Whirr Handler [CMClusterProvision]   http://37.188.114.234:7180
 Whirr Handler [CMClusterProvision]   ssh -o StrictHostKeyChecking=no -i /root/.ssh/whirr whirr@37.188.114.234
 ```
 
-You are able to log into the CM Web Console at any stage and observe proceedings.
+You are able to log into the CM Web Console (or hosts) at any stage and observe proceedings.
 
 The default admin user credentials are: 
 

--- a/cm-ec2.properties
+++ b/cm-ec2.properties
@@ -18,9 +18,8 @@
 # The name of the cluster, must be made up of alpha-numeric values only
 whirr.cluster-name=whirr
 
-# Change the number of the last instance template token (intially set to 3)
-# to change the size of the cluster
-whirr.instance-templates=1 cm-server+cm-agent,1 cm-agent+cm-cdh-namenode+cm-cdh-zookeeper,1 cm-agent+cm-cdh-secondarynamenode+cm-cdh-oozie-server+cm-cdh-hbase-master+cm-cdh-zookeeper,1 cm-agent+cm-cdh-jobtracker+cm-cdh-hivemetastore+cm-cdh-impala-statestore+cm-cdh-hue-server+cm-cdh-hue-beeswaxserver+cm-cdh-zookeeper,3 cm-agent+cm-cdh-datanode+cm-cdh-tasktracker+cm-cdh-hbase-regionserver+cm-cdh-impala-daemon
+# Define the cluster topology, initially defining 1 master node and 3 slave nodes
+whirr.instance-templates=1 cm-server+cm-agent,1 cm-agent+cm-cdh-namenode+cm-cdh-secondarynamenode+cm-cdh-oozie-server+cm-cdh-hbase-master+cm-cdh-jobtracker+cm-cdh-hivemetastore+cm-cdh-impala-statestore+cm-cdh-hue-server+cm-cdh-hue-beeswaxserver,3 cm-agent+cm-cdh-datanode+cm-cdh-tasktracker+cm-cdh-hbase-regionserver+cm-cdh-impala-daemon+cm-cdh-zookeeper
 
 # The private key used by the Cloudera Manager cluster
 whirr.private-key-file=${sys:user.home}/.ssh/id_rsa_cm
@@ -38,7 +37,7 @@ whirr.image-id=us-east-1/ami-ccb35ea5
 whirr.location-id=us-east-1
 
 # Switch to enable/disable the automatic setup of a cluster within Cloudera Manager,
-# its initialization and launch 
+# its initialization and launch, defaults to true
 whirr.env.cmauto=true
 
 # Provide Cloudera Manager settings with prefix 'whirr.cm.config.' followed by
@@ -46,8 +45,7 @@ whirr.env.cmauto=true
 whirr.cm.config.CUSTOM_BANNER_HTML=My Cloudera Manager managed, Whirr provisioned CDH Cluster
 
 # Provide an escaped comma separated list (eg \\,) of Parcel Repo Mirrors
-# (potentially closer to or vetted by your organisation), which in turn dictate the
+# (potentially closer to and or vetted by your organisation), which in turn dictate the
 # version of parcels installed - Cloudera Manager selects the latest available
 # (see http://archive.cloudera.com/cdh4/parcels and http://beta.cloudera.com/impala/parcels)
 whirr.cm.config.REMOTE_PARCEL_REPO_URLS=http://archive.cloudera.com/cdh4/parcels/latest/\\,http://beta.cloudera.com/impala/parcels/latest/
-

--- a/src/main/java/com/cloudera/whirr/cm/CmConstants.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmConstants.java
@@ -21,6 +21,8 @@ import com.cloudera.whirr.cm.server.CmServerConstants;
 
 public interface CmConstants extends CmServerConstants {
 
+  public static final String PROPERTIES_FILE = "whirr-cm-default.properties";
+
   public static final String CM_USER = "admin";
   public static final String CM_PASSWORD = "admin";
 

--- a/src/main/java/com/cloudera/whirr/cm/CmConstants.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmConstants.java
@@ -24,10 +24,6 @@ public interface CmConstants extends CmServerConstants {
   public static final String CM_USER = "admin";
   public static final String CM_PASSWORD = "admin";
 
-  public static final String CONFIG_WHIRR_NAME = "whirr.cluster-name";
-  public static final String CONFIG_WHIRR_USER = "whirr.cluster-user";
-  public static final String CONFIG_WHIRR_PRIV_KEY = "whirr.private-key-file";
-  public static final String CONFIG_WHIRR_PUB_KEY = "whirr.public-key-file";
   public static final String CONFIG_WHIRR_AUTO_VARIABLE = "whirr.env.cmauto";
   public static final String CONFIG_WHIRR_USE_PACKAGES = "whirr.cm.use.packages";
   public static final String CONFIG_WHIRR_CM_PREFIX = "whirr.cm.config.";

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -155,7 +155,8 @@ public class CmServerClusterInstance implements CmConstants {
     }
     logger.logOperationInProgressSync(label, "CM SERVER");
     if (cluster.getServer() != null) {
-      logger.logOperationInProgressSync(label, "  http://" + cluster.getServer() + ":7180");
+      logger.logOperationInProgressSync(label,
+          "  http://" + cluster.getServer() + ":" + configuration.getString(CmServerHandler.PROPERTY_PORT_WEB));
       logger.logOperationInProgressSync(
           label,
           "  ssh -o StrictHostKeyChecking=no -i "

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -23,7 +23,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.whirr.Cluster.Instance;
 import org.apache.whirr.ClusterSpec;
 
@@ -46,6 +49,18 @@ public class CmServerClusterInstance implements CmConstants {
   private static boolean isStandaloneCommand = true;
 
   private CmServerClusterInstance() {
+  }
+
+  public static Configuration getConfiguration(ClusterSpec clusterSpec) throws IOException {
+    try {
+      CompositeConfiguration configuration = new CompositeConfiguration();
+      configuration.addConfiguration(clusterSpec.getConfiguration());
+      configuration.addConfiguration(new PropertiesConfiguration(CmServerClusterInstance.class.getClassLoader()
+          .getResource(PROPERTIES_FILE)));
+      return configuration;
+    } catch (ConfigurationException e) {
+      throw new IOException("Error loading " + PROPERTIES_FILE, e);
+    }
   }
 
   public static synchronized boolean isStandaloneCommand() {

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -43,7 +43,7 @@ public class CmServerClusterInstance implements CmConstants {
 
   private static CmServerFactory factory;
   private static CmServerCluster cluster;
-  private static boolean isStandaloneCommand = false;
+  private static boolean isStandaloneCommand = true;
 
   private CmServerClusterInstance() {
   }

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -179,7 +179,7 @@ public class CmServerClusterInstance implements CmConstants {
   }
 
   public static void logException(CmServerLog logger, String operation, String message, Throwable throwable) {
-    logger.logOperationInProgressSync(operation, "Failed");
+    logger.logOperationInProgressSync(operation, "failed");
     logger.logOperationStackTrace(operation, throwable);
     logger.logSpacer();
     logger.logOperation(operation, message);

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -86,20 +86,15 @@ public class CmServerClusterInstance implements CmConstants {
         } else {
           CmServerServiceType type = BaseHandlerCmCdh.getRolesToType().get(role);
           if (type != null && (roles == null || roles.isEmpty() || roles.contains(role))) {
-            cluster.addService(getClusterService(specification, instance, type));
+            cluster.addService(new CmServerServiceBuilder().type(type)
+                .tag(specification.getConfiguration().getString(CONFIG_WHIRR_NAME, CONFIG_WHIRR_NAME_DEFAULT))
+                .qualifier("" + (cluster.getServices(type).size() + 1)).ip(instance.getPublicIp())
+                .ipInternal(instance.getPrivateIp()).build());
           }
         }
       }
     }
     return cluster;
-  }
-
-  public static CmServerService getClusterService(ClusterSpec specification, Instance instance, CmServerServiceType type)
-      throws CmServerException, IOException {
-    return new CmServerServiceBuilder().type(type)
-        .tag(specification.getConfiguration().getString(CONFIG_WHIRR_NAME, CONFIG_WHIRR_NAME_DEFAULT))
-        .qualifier("" + (cluster.getServices(type).size() + 1)).host(instance.getPublicHostName())
-        .ip(instance.getPublicIp()).ipInternal(instance.getPrivateIp()).build();
   }
 
   public static CmServerCluster getCluster(CmServerCluster cluster) throws CmServerException {

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -130,21 +130,22 @@ public class CmServerClusterInstance implements CmConstants {
       logger.logOperationInProgressSync(label, "CM AGENTS");
     }
     for (String cmAgent : cluster.getAgents()) {
-      logger.logOperationInProgressSync(label, "  ssh -o StrictHostKeyChecking=no " + specification.getClusterUser()
-          + "@" + cmAgent);
+      logger.logOperationInProgressSync(label, "  ssh -o StrictHostKeyChecking=no -i "
+          + specification.getPrivateKeyFile().getAbsolutePath() + " " + specification.getClusterUser() + "@" + cmAgent);
     }
     if (!cluster.getNodes().isEmpty()) {
       logger.logOperationInProgressSync(label, "CM NODES");
     }
     for (String cmNode : cluster.getNodes()) {
-      logger.logOperationInProgressSync(label, "  ssh -o StrictHostKeyChecking=no " + specification.getClusterUser()
-          + "@" + cmNode);
+      logger.logOperationInProgressSync(label, "  ssh -o StrictHostKeyChecking=no -i "
+          + specification.getPrivateKeyFile().getAbsolutePath() + " " + specification.getClusterUser() + "@" + cmNode);
     }
     logger.logOperationInProgressSync(label, "CM SERVER");
     if (cluster.getServer() != null) {
       logger.logOperationInProgressSync(label, "  http://" + cluster.getServer() + ":7180");
-      logger.logOperationInProgressSync(label, "  ssh -o StrictHostKeyChecking=no " + specification.getClusterUser()
-          + "@" + cluster.getServer());
+      logger.logOperationInProgressSync(label,
+          "  ssh -o StrictHostKeyChecking=no -i " + specification.getPrivateKeyFile().getAbsolutePath() + " "
+              + specification.getClusterUser() + "@" + cluster.getServer());
     } else {
       logger.logOperationInProgressSync(label, "NO CM SERVER");
     }

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -43,8 +43,17 @@ public class CmServerClusterInstance implements CmConstants {
 
   private static CmServerFactory factory;
   private static CmServerCluster cluster;
+  private static boolean isStandaloneCommand = false;
 
   private CmServerClusterInstance() {
+  }
+
+  public static synchronized boolean isStandaloneCommand() {
+    return isStandaloneCommand;
+  }
+
+  public static synchronized void setIsStandaloneCommand(boolean isStandaloneCommand) {
+    CmServerClusterInstance.isStandaloneCommand = isStandaloneCommand;
   }
 
   public static synchronized CmServerFactory getFactory() {

--- a/src/main/java/com/cloudera/whirr/cm/cmd/BaseCommandCmServer.java
+++ b/src/main/java/com/cloudera/whirr/cm/cmd/BaseCommandCmServer.java
@@ -67,8 +67,8 @@ public abstract class BaseCommandCmServer extends BaseCommand {
   public abstract int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand)
       throws Exception;
 
-  private OptionSpec<String> name = parser.accepts("name", "Cluster name to target").withRequiredArg()
-      .ofType(String.class);
+  private OptionSpec<String> cmClusterName = parser.accepts("cm-cluster-name", "CM cluster name to target")
+      .withRequiredArg().ofType(String.class);
 
   private OptionSpec<String> rolesOption = isRoleFilterable() ? parser.accepts("roles", "Cluster roles to target")
       .withRequiredArg().ofType(String.class) : null;
@@ -90,8 +90,8 @@ public abstract class BaseCommandCmServer extends BaseCommand {
     CmServerCluster cluster = CmServerClusterInstance.getCluster(specification.getConfiguration(),
         clusterController.getInstances(specification, clusterStateStore), Collections.<String> emptySet(), roles);
 
-    if (optionSet.hasArgument(name)) {
-      cluster.setName(optionSet.valueOf(name));
+    if (optionSet.hasArgument(cmClusterName)) {
+      cluster.setName(optionSet.valueOf(cmClusterName));
     }
 
     if (cluster.getServer() == null) {
@@ -117,7 +117,7 @@ public abstract class BaseCommandCmServer extends BaseCommand {
 
   @Override
   public void printUsage(PrintStream stream) throws IOException {
-    stream.println("Usage: whirr " + getName() + " [OPTIONS] [--name cluster-name]"
+    stream.println("Usage: whirr " + getName() + " [OPTIONS] [--cm-cluster-name \"My cluster\"]"
         + (isRoleFilterable() ? " [--roles role1,role2]" : ""));
     stream.println();
     parser.printHelpOn(stream);

--- a/src/main/java/com/cloudera/whirr/cm/cmd/BaseCommandCmServer.java
+++ b/src/main/java/com/cloudera/whirr/cm/cmd/BaseCommandCmServer.java
@@ -84,7 +84,7 @@ public abstract class BaseCommandCmServer extends BaseCommand {
       }
     }
 
-    CmServerCluster cluster = CmServerClusterInstance.getCluster(specification,
+    CmServerCluster cluster = CmServerClusterInstance.getCluster(specification.getConfiguration(),
         clusterController.getInstances(specification, clusterStateStore), Collections.<String> emptySet(), roles);
 
     if (cluster.getServer() == null) {

--- a/src/main/java/com/cloudera/whirr/cm/cmd/CmServerCleanClusterCommand.java
+++ b/src/main/java/com/cloudera/whirr/cm/cmd/CmServerCleanClusterCommand.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.whirr.cm.cmd;
+
+import java.io.IOException;
+import org.apache.whirr.ClusterControllerFactory;
+import org.apache.whirr.ClusterSpec;
+import org.apache.whirr.state.ClusterStateStoreFactory;
+
+import com.cloudera.whirr.cm.server.CmServerCluster;
+import com.cloudera.whirr.cm.server.CmServerBuilder;
+
+public class CmServerCleanClusterCommand extends BaseCommandCmServer {
+
+  public static final String NAME = "clean-cluster";
+  public static final String DESCRIPTION = "Terminate and cleanup resources for the cluster.";
+
+  public CmServerCleanClusterCommand() throws IOException {
+    this(new ClusterControllerFactory());
+  }
+
+  public CmServerCleanClusterCommand(ClusterControllerFactory factory) {
+    this(factory, new ClusterStateStoreFactory());
+  }
+
+  public CmServerCleanClusterCommand(ClusterControllerFactory factory, ClusterStateStoreFactory stateStoreFactory) {
+    super(NAME, DESCRIPTION, factory, stateStoreFactory);
+  }
+
+  @Override
+  public boolean isRoleFilterable() {
+    return false;
+  }
+  
+  @Override
+  public int run(ClusterSpec specification,  CmServerCluster cluster,
+      CmServerBuilder serverCommand) throws Exception {
+    return serverCommand.command("unprovision").executeBoolean() ? 0 : -1;
+  }
+
+}

--- a/src/main/java/com/cloudera/whirr/cm/cmd/CmServerCreateServicesCommand.java
+++ b/src/main/java/com/cloudera/whirr/cm/cmd/CmServerCreateServicesCommand.java
@@ -25,6 +25,7 @@ import org.apache.whirr.state.ClusterStateStoreFactory;
 
 import com.cloudera.whirr.cm.server.CmServerCluster;
 import com.cloudera.whirr.cm.server.CmServerBuilder;
+import com.cloudera.whirr.cm.server.CmServerServiceType;
 
 public class CmServerCreateServicesCommand extends BaseCommandCmServer {
 

--- a/src/main/java/com/cloudera/whirr/cm/cmd/CmServerCreateServicesCommand.java
+++ b/src/main/java/com/cloudera/whirr/cm/cmd/CmServerCreateServicesCommand.java
@@ -23,9 +23,8 @@ import org.apache.whirr.ClusterControllerFactory;
 import org.apache.whirr.ClusterSpec;
 import org.apache.whirr.state.ClusterStateStoreFactory;
 
-import com.cloudera.whirr.cm.server.CmServerCluster;
 import com.cloudera.whirr.cm.server.CmServerBuilder;
-import com.cloudera.whirr.cm.server.CmServerServiceType;
+import com.cloudera.whirr.cm.server.CmServerCluster;
 
 public class CmServerCreateServicesCommand extends BaseCommandCmServer {
 

--- a/src/main/java/com/cloudera/whirr/cm/cmd/CmServerListServicesCommand.java
+++ b/src/main/java/com/cloudera/whirr/cm/cmd/CmServerListServicesCommand.java
@@ -24,8 +24,8 @@ import org.apache.whirr.ClusterSpec;
 import org.apache.whirr.state.ClusterStateStoreFactory;
 
 import com.cloudera.whirr.cm.CmServerClusterInstance;
-import com.cloudera.whirr.cm.server.CmServerCluster;
 import com.cloudera.whirr.cm.server.CmServerBuilder;
+import com.cloudera.whirr.cm.server.CmServerCluster;
 
 public class CmServerListServicesCommand extends BaseCommandCmServer {
 
@@ -49,7 +49,8 @@ public class CmServerListServicesCommand extends BaseCommandCmServer {
     CmServerCluster clusterOutput = serverCommand.command("services").executeCluster();
     CmServerClusterInstance.logLineItemFooter(logger, getLabel());
     CmServerClusterInstance.logLineItem(logger, getLabel());
-    CmServerClusterInstance.logCluster(logger, getLabel(), specification.getConfiguration(), clusterOutput);
+    CmServerClusterInstance.logCluster(logger, getLabel(), CmServerClusterInstance.getConfiguration(specification),
+        clusterOutput);
     return 0;
   }
 }

--- a/src/main/java/com/cloudera/whirr/cm/cmd/CmServerListServicesCommand.java
+++ b/src/main/java/com/cloudera/whirr/cm/cmd/CmServerListServicesCommand.java
@@ -49,7 +49,7 @@ public class CmServerListServicesCommand extends BaseCommandCmServer {
     CmServerCluster clusterOutput = serverCommand.command("services").executeCluster();
     CmServerClusterInstance.logLineItemFooter(logger, getLabel());
     CmServerClusterInstance.logLineItem(logger, getLabel());
-    CmServerClusterInstance.logCluster(logger, getLabel(), specification, clusterOutput);
+    CmServerClusterInstance.logCluster(logger, getLabel(), specification.getConfiguration(), clusterOutput);
     return 0;
   }
 }

--- a/src/main/java/com/cloudera/whirr/cm/handler/BaseHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/BaseHandler.java
@@ -20,7 +20,6 @@ package com.cloudera.whirr.cm.handler;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
-import org.apache.commons.configuration.Configuration;
 import org.apache.whirr.ClusterSpec;
 import org.apache.whirr.service.ClusterActionEvent;
 import org.apache.whirr.service.ClusterActionHandlerSupport;
@@ -34,21 +33,17 @@ public abstract class BaseHandler extends ClusterActionHandlerSupport implements
 
   protected static final String CONFIG_IMPORT_PATH = "functions/cmf/";
 
-  private static final String PROPERTIES_FILE = "whirr-cm-default.properties";
-
-  protected Configuration getConfiguration(ClusterSpec spec) throws IOException {
-    return getConfiguration(spec, PROPERTIES_FILE);
-  }
-
   @Override
   protected void beforeBootstrap(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeBootstrap(event);
     if (!CM_CLUSTER_NAME_REGEX.matcher(
-        event.getClusterSpec().getConfiguration().getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT)).matches()) {
+        event.getClusterSpec().getConfiguration()
+            .getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT)).matches()) {
       throw new IOException("Illegal cluster name ["
-          + event.getClusterSpec().getConfiguration().getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT)
-          + "] passed in variable [" + ClusterSpec.Property.CLUSTER_NAME.getConfigName() + "] with default [" + CONFIG_WHIRR_NAME_DEFAULT
-          + "]. Please use only alphanumeric characters.");
+          + event.getClusterSpec().getConfiguration()
+              .getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT)
+          + "] passed in variable [" + ClusterSpec.Property.CLUSTER_NAME.getConfigName() + "] with default ["
+          + CONFIG_WHIRR_NAME_DEFAULT + "]. Please use only alphanumeric characters.");
     }
   }
 

--- a/src/main/java/com/cloudera/whirr/cm/handler/BaseHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/BaseHandler.java
@@ -44,10 +44,10 @@ public abstract class BaseHandler extends ClusterActionHandlerSupport implements
   protected void beforeBootstrap(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeBootstrap(event);
     if (!CM_CLUSTER_NAME_REGEX.matcher(
-        event.getClusterSpec().getConfiguration().getString(CONFIG_WHIRR_NAME, CONFIG_WHIRR_NAME_DEFAULT)).matches()) {
+        event.getClusterSpec().getConfiguration().getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT)).matches()) {
       throw new IOException("Illegal cluster name ["
-          + event.getClusterSpec().getConfiguration().getString(CONFIG_WHIRR_NAME, CONFIG_WHIRR_NAME_DEFAULT)
-          + "] passed in variable [" + CONFIG_WHIRR_NAME + "] with default [" + CONFIG_WHIRR_NAME_DEFAULT
+          + event.getClusterSpec().getConfiguration().getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT)
+          + "] passed in variable [" + ClusterSpec.Property.CLUSTER_NAME.getConfigName() + "] with default [" + CONFIG_WHIRR_NAME_DEFAULT
           + "]. Please use only alphanumeric characters.");
     }
   }

--- a/src/main/java/com/cloudera/whirr/cm/handler/BaseHandlerCm.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/BaseHandlerCm.java
@@ -65,7 +65,7 @@ public abstract class BaseHandlerCm extends BaseHandler {
     logHeaderHandler("HostConfigure");
     super.beforeConfigure(event);
     addStatement(event, call("retry_helpers"));
-    if (getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_ROOT) == null) {
+    if (CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_ROOT) == null) {
       getDeviceMappings(event);
       String devMappings = VolumeManager.asString(deviceMappings);
       addStatement(event, call("prepare_all_disks", "'" + devMappings + "'"));

--- a/src/main/java/com/cloudera/whirr/cm/handler/BaseHandlerCm.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/BaseHandlerCm.java
@@ -70,7 +70,12 @@ public abstract class BaseHandlerCm extends BaseHandler {
       String devMappings = VolumeManager.asString(deviceMappings);
       addStatement(event, call("prepare_all_disks", "'" + devMappings + "'"));
     }
+  }
+
+  @Override
+  protected void afterConfigure(ClusterActionEvent event) throws IOException, InterruptedException {
     logFooterHandler("HostConfigure");
+    super.afterConfigure(event);
   }
 
   public Map<String, String> getDeviceMappings(ClusterActionEvent event) {

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmAgentHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmAgentHandler.java
@@ -67,7 +67,7 @@ public class CmAgentHandler extends CmNodeHandler {
           event,
           call("configure_cm_agent", "-h", event.getCluster().getInstanceMatching(role(CmServerHandler.ROLE))
               .getPrivateIp(), "-p",
-              getConfiguration(event.getClusterSpec()).getString(CmServerHandler.PROPERTY_PORT_COMMS)));
+              CmServerClusterInstance. getConfiguration(event.getClusterSpec()).getString(CmServerHandler.PROPERTY_PORT_COMMS)));
     }
   }
 

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmAgentHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmAgentHandler.java
@@ -27,6 +27,7 @@ import org.apache.whirr.service.ClusterActionEvent;
 
 import com.cloudera.whirr.cm.CmServerClusterInstance;
 import com.cloudera.whirr.cm.server.CmServerException;
+import com.cloudera.whirr.cm.server.CmServerServiceBuilder;
 
 public class CmAgentHandler extends CmNodeHandler {
 
@@ -46,7 +47,7 @@ public class CmAgentHandler extends CmNodeHandler {
   protected void beforeBootstrap(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeBootstrap(event);
     try {
-      CmServerClusterInstance.getCluster().addAgent(getInstanceId());
+      CmServerClusterInstance.getCluster().addAgent(new CmServerServiceBuilder().host(getInstanceId()).build());
     } catch (CmServerException e) {
       throw new IOException("Unexpected error building cluster", e);
     }
@@ -65,7 +66,7 @@ public class CmAgentHandler extends CmNodeHandler {
       addStatement(
           event,
           call("configure_cm_agent", "-h", event.getCluster().getInstanceMatching(role(CmServerHandler.ROLE))
-              .getPublicIp(), "-p",
+              .getPrivateIp(), "-p",
               getConfiguration(event.getClusterSpec()).getString(CmServerHandler.PROPERTY_PORT_COMMS)));
     }
   }

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmNodeHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmNodeHandler.java
@@ -27,6 +27,7 @@ import org.apache.whirr.service.FirewallManager.Rule;
 
 import com.cloudera.whirr.cm.CmServerClusterInstance;
 import com.cloudera.whirr.cm.server.CmServerException;
+import com.cloudera.whirr.cm.server.CmServerServiceBuilder;
 
 public class CmNodeHandler extends BaseHandlerCm {
   public static final String ROLE = "cm-node";
@@ -47,7 +48,7 @@ public class CmNodeHandler extends BaseHandlerCm {
   protected void beforeBootstrap(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeBootstrap(event);
     try {
-      CmServerClusterInstance.getCluster().addNode(getInstanceId());
+      CmServerClusterInstance.getCluster().addNode(new CmServerServiceBuilder().host(getInstanceId()).build());
     } catch (CmServerException e) {
       throw new IOException("Unexpected error building cluster", e);
     }

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmNodeHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmNodeHandler.java
@@ -59,7 +59,7 @@ public class CmNodeHandler extends BaseHandlerCm {
   protected void beforeConfigure(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeConfigure(event);
 
-    for (Object port : getConfiguration(event.getClusterSpec()).getList(PROPERTY_PORTS)) {
+    for (Object port : CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getList(PROPERTY_PORTS)) {
       if (port != null && !"".equals(port))
         event.getFirewallManager().addRule(
             Rule.create().destination(role(getRole())).port(Integer.parseInt(port.toString())));

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
@@ -118,9 +118,6 @@ public class CmServerHandler extends BaseHandlerCm {
           }
         }
         server.initialise(config);
-        if (!server.provision(clusterInput)) {
-          throw new CmServerException("Unexepcted error attempting to provision cluster");
-        }
         return clusterInput;
       }
     }, false, true);
@@ -139,9 +136,11 @@ public class CmServerHandler extends BaseHandlerCm {
           }
         }
         boolean success = false;
-        if (server.configure(clusterInput)) {
-          if (server.getServiceConfigs(clusterInput, event.getClusterSpec().getClusterDirectory())) {
-            success = true;
+        if (server.provision(clusterInput)) {
+          if (server.configure(clusterInput)) {
+            if (server.getServiceConfigs(clusterInput, event.getClusterSpec().getClusterDirectory())) {
+              success = true;
+            }
           }
         }
         if (!success) {

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
@@ -191,11 +191,14 @@ public class CmServerHandler extends BaseHandlerCm {
           CmServer server = CmServerClusterInstance.getFactory().getCmServer(
               event.getCluster().getInstanceMatching(role(ROLE)).getPublicIp(), 7180, CM_USER, CM_PASSWORD,
               new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API, false));
-          cluster = command.execute(event, server, cluster);
-          CmServerClusterInstance.logLineItemFooter(logger, operation);
-          CmServerClusterInstance.logLineItem(logger, operation);
-          CmServerClusterInstance.logCluster(logger, operation, event.getClusterSpec(), cluster);
-          CmServerClusterInstance.logLineItemFooter(logger, operation);
+          try {
+            cluster = command.execute(event, server, cluster);
+          } finally {
+            CmServerClusterInstance.logLineItemFooter(logger, operation);
+            CmServerClusterInstance.logLineItem(logger, operation);
+            CmServerClusterInstance.logCluster(logger, operation, event.getClusterSpec(), cluster);
+            CmServerClusterInstance.logLineItemFooter(logger, operation);
+          }
         }
       }
     } catch (Exception e) {

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
@@ -90,9 +90,9 @@ public class CmServerHandler extends BaseHandlerCm {
     }
     addStatement(event, call("configure_cm_server"));
     @SuppressWarnings("unchecked")
-    List<String> ports = getConfiguration(event.getClusterSpec()).getList(PROPERTY_PORTS);
-    ports.add(getConfiguration(event.getClusterSpec()).getString(PROPERTY_PORT_WEB));
-    ports.add(getConfiguration(event.getClusterSpec()).getString(PROPERTY_PORT_COMMS));
+    List<String> ports = CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getList(PROPERTY_PORTS);
+    ports.add(CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getString(PROPERTY_PORT_WEB));
+    ports.add(CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getString(PROPERTY_PORT_COMMS));
     for (String port : ports) {
       if (port != null && !"".equals(port))
         event.getFirewallManager().addRule(Rule.create().destination(role(ROLE)).port(Integer.parseInt(port)));
@@ -207,20 +207,26 @@ public class CmServerHandler extends BaseHandlerCm {
           CmServerClusterInstance.logLineItemDetail(logger, operation, "[" + CONFIG_WHIRR_AUTO_VARIABLE
               + "] is false so not executing");
         } else {
-          CmServerClusterInstance.logLineItem(logger, operation,
-              "follow live at http://" + event.getCluster().getInstanceMatching(role(ROLE)).getPublicIp() + ":"
-                  + getConfiguration(event.getClusterSpec()).getString(CmServerHandler.PROPERTY_PORT_WEB));
+          CmServerClusterInstance.logLineItem(
+              logger,
+              operation,
+              "follow live at http://"
+                  + event.getCluster().getInstanceMatching(role(ROLE)).getPublicIp()
+                  + ":"
+                  + CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getString(
+                      CmServerHandler.PROPERTY_PORT_WEB));
           CmServerClusterInstance.logLineItem(logger, operation);
           CmServer server = CmServerClusterInstance.getFactory().getCmServer(
               event.getCluster().getInstanceMatching(role(ROLE)).getPublicIp(),
-              getConfiguration(event.getClusterSpec()).getInt(PROPERTY_PORT_WEB), CM_USER, CM_PASSWORD,
-              new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API, false));
+              CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getInt(PROPERTY_PORT_WEB), CM_USER,
+              CM_PASSWORD, new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API, false));
           try {
             cluster = command.execute(event, server, cluster);
           } finally {
             CmServerClusterInstance.logLineItemFooter(logger, operation);
             CmServerClusterInstance.logLineItem(logger, operation);
-            CmServerClusterInstance.logCluster(logger, operation, getConfiguration(event.getClusterSpec()), cluster);
+            CmServerClusterInstance.logCluster(logger, operation,
+                CmServerClusterInstance.getConfiguration(event.getClusterSpec()), cluster);
             CmServerClusterInstance.logLineItemFooter(logger, operation);
           }
         }
@@ -240,7 +246,8 @@ public class CmServerHandler extends BaseHandlerCm {
       IOException {
     CmServerCluster clusterStale = CmServerClusterInstance.getCluster();
     CmServerCluster cluster, clusterCurrent = cluster = CmServerClusterInstance.getCluster(
-        getConfiguration(event.getClusterSpec()), event.getCluster().getInstances(), getDataMounts(event));
+        CmServerClusterInstance.getConfiguration(event.getClusterSpec()), event.getCluster().getInstances(),
+        getDataMounts(event));
     if (status != null) {
       CmServerCluster clusterFiltered = CmServerClusterInstance.getCluster(clusterCurrent);
       for (CmServerServiceType type : clusterStale.getServiceTypes()) {
@@ -265,13 +272,13 @@ public class CmServerHandler extends BaseHandlerCm {
 
   private Set<String> getDataMounts(ClusterActionEvent event) throws IOException {
     Set<String> mounts = new HashSet<String>();
-    String overirdeMounts = getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_ROOT);
+    String overirdeMounts = CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_ROOT);
     if (overirdeMounts != null) {
       mounts.add(overirdeMounts);
     } else if (!getDeviceMappings(event).isEmpty()) {
       mounts.addAll(getDeviceMappings(event).keySet());
     } else {
-      mounts.add(getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_DEFAULT));
+      mounts.add(CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getString(DATA_DIRS_DEFAULT));
     }
     return mounts;
   }

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
@@ -187,9 +187,13 @@ public class CmServerHandler extends BaseHandlerCm {
           CmServerClusterInstance.logLineItemDetail(logger, operation, "[" + CONFIG_WHIRR_AUTO_VARIABLE
               + "] is false so not executing");
         } else if (event.getClusterSpec().getConfiguration().getBoolean(CONFIG_WHIRR_AUTO_VARIABLE, true)) {
+          CmServerClusterInstance.logLineItem(logger, operation,
+              "follow live at http://" + event.getCluster().getInstanceMatching(role(ROLE)).getPublicIp() + ":"
+                  + getConfiguration(event.getClusterSpec()).getString(CmServerHandler.PROPERTY_PORT_WEB));
           CmServerClusterInstance.logLineItem(logger, operation);
           CmServer server = CmServerClusterInstance.getFactory().getCmServer(
-              event.getCluster().getInstanceMatching(role(ROLE)).getPublicIp(), 7180, CM_USER, CM_PASSWORD,
+              event.getCluster().getInstanceMatching(role(ROLE)).getPublicIp(),
+              getConfiguration(event.getClusterSpec()).getInt(PROPERTY_PORT_WEB), CM_USER, CM_PASSWORD,
               new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API, false));
           try {
             cluster = command.execute(event, server, cluster);

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
@@ -67,6 +67,7 @@ public class CmServerHandler extends BaseHandlerCm {
   protected void beforeBootstrap(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeBootstrap(event);
     try {
+      CmServerClusterInstance.setIsStandaloneCommand(false);
       CmServerClusterInstance.getCluster().setServer(getInstanceId());
     } catch (CmServerException e) {
       throw new IOException("Unexpected error building cluster", e);
@@ -182,11 +183,12 @@ public class CmServerHandler extends BaseHandlerCm {
       CmServerClusterInstance.logHeader(logger, operation);
       CmServerCluster cluster = getCluster(event, status);
       if (!cluster.isEmpty()) {
-        if (!event.getClusterSpec().getConfiguration().getBoolean(CONFIG_WHIRR_AUTO_VARIABLE, true)) {
+        if (!CmServerClusterInstance.isStandaloneCommand()
+            && !event.getClusterSpec().getConfiguration().getBoolean(CONFIG_WHIRR_AUTO_VARIABLE, true)) {
           CmServerClusterInstance.logLineItem(logger, operation, "Warning, services found, but whirr property");
           CmServerClusterInstance.logLineItemDetail(logger, operation, "[" + CONFIG_WHIRR_AUTO_VARIABLE
               + "] is false so not executing");
-        } else if (event.getClusterSpec().getConfiguration().getBoolean(CONFIG_WHIRR_AUTO_VARIABLE, true)) {
+        } else {
           CmServerClusterInstance.logLineItem(logger, operation,
               "follow live at http://" + event.getCluster().getInstanceMatching(role(ROLE)).getPublicIp() + ":"
                   + getConfiguration(event.getClusterSpec()).getString(CmServerHandler.PROPERTY_PORT_WEB));

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
@@ -196,7 +196,7 @@ public class CmServerHandler extends BaseHandlerCm {
           } finally {
             CmServerClusterInstance.logLineItemFooter(logger, operation);
             CmServerClusterInstance.logLineItem(logger, operation);
-            CmServerClusterInstance.logCluster(logger, operation, event.getClusterSpec(), cluster);
+            CmServerClusterInstance.logCluster(logger, operation, getConfiguration(event.getClusterSpec()), cluster);
             CmServerClusterInstance.logLineItemFooter(logger, operation);
           }
         }
@@ -215,8 +215,8 @@ public class CmServerHandler extends BaseHandlerCm {
   private CmServerCluster getCluster(ClusterActionEvent event, CmServerServiceStatus status) throws CmServerException,
       IOException {
     CmServerCluster clusterStale = CmServerClusterInstance.getCluster();
-    CmServerCluster cluster, clusterCurrent = cluster = CmServerClusterInstance.getCluster(event.getClusterSpec(),
-        event.getCluster().getInstances(), getDataMounts(event));
+    CmServerCluster cluster, clusterCurrent = cluster = CmServerClusterInstance.getCluster(
+        getConfiguration(event.getClusterSpec()), event.getCluster().getInstances(), getDataMounts(event));
     if (status != null) {
       CmServerCluster clusterFiltered = CmServerClusterInstance.getCluster(clusterCurrent);
       for (CmServerServiceType type : clusterStale.getServiceTypes()) {

--- a/src/main/java/com/cloudera/whirr/cm/handler/cdh/BaseHandlerCmCdh.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/cdh/BaseHandlerCmCdh.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
+import org.apache.whirr.ClusterSpec;
 import org.apache.whirr.service.ClusterActionEvent;
 import org.apache.whirr.service.ClusterActionHandler;
 
@@ -48,7 +49,7 @@ public abstract class BaseHandlerCmCdh extends BaseHandler {
       }
       CmServerClusterInstance.getCluster().addService(
           new CmServerServiceBuilder().type(getType())
-              .tag(event.getClusterSpec().getConfiguration().getString(CONFIG_WHIRR_NAME, CONFIG_WHIRR_NAME_DEFAULT))
+              .tag(event.getClusterSpec().getConfiguration().getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT))
               .build());
     } catch (CmServerException e) {
       throw new IOException("Unexpected error building cluster", e);
@@ -81,7 +82,7 @@ public abstract class BaseHandlerCmCdh extends BaseHandler {
     try {
       CmServerClusterInstance.getCluster().addService(
           new CmServerServiceBuilder().type(getType())
-              .tag(event.getClusterSpec().getConfiguration().getString(CONFIG_WHIRR_NAME, CONFIG_WHIRR_NAME_DEFAULT))
+              .tag(event.getClusterSpec().getConfiguration().getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT))
               .status(CmServerService.CmServerServiceStatus.STARTING).build());
     } catch (CmServerException e) {
       throw new IOException("Unexpected error building cluster", e);
@@ -94,7 +95,7 @@ public abstract class BaseHandlerCmCdh extends BaseHandler {
     try {
       CmServerClusterInstance.getCluster().addService(
           new CmServerServiceBuilder().type(getType())
-              .tag(event.getClusterSpec().getConfiguration().getString(CONFIG_WHIRR_NAME, CONFIG_WHIRR_NAME_DEFAULT))
+              .tag(event.getClusterSpec().getConfiguration().getString(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT))
               .status(CmServerService.CmServerServiceStatus.STOPPING).build());
     } catch (CmServerException e) {
       throw new IOException("Unexpected error building cluster", e);

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerCluster.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerCluster.java
@@ -33,8 +33,8 @@ public class CmServerCluster {
 
   private String server;
   private boolean isParcel = true;
-  private Set<String> agents = new TreeSet<String>();
-  private Set<String> nodes = new TreeSet<String>();
+  private Set<CmServerService> agents = new HashSet<CmServerService>();
+  private Set<CmServerService> nodes = new HashSet<CmServerService>();
   private Set<String> mounts = new HashSet<String>();
   private Map<CmServerServiceType, Set<CmServerService>> services = new HashMap<CmServerServiceType, Set<CmServerService>>();
 
@@ -85,14 +85,14 @@ public class CmServerCluster {
     return (this.server = server) != null;
   }
 
-  public synchronized boolean addAgent(String agent) throws CmServerException {
+  public synchronized boolean addAgent(CmServerService agent) throws CmServerException {
     if (!agents.add(agent)) {
       throw new CmServerException("Invalid cluster topology: Attempt to add col-located agents");
     }
     return true;
   }
 
-  public synchronized boolean addNode(String node) throws CmServerException {
+  public synchronized boolean addNode(CmServerService node) throws CmServerException {
     if (!nodes.add(node)) {
       throw new CmServerException("Invalid cluster topology: Attempt to add co-located nodes");
     }
@@ -170,12 +170,12 @@ public class CmServerCluster {
     return server;
   }
 
-  public synchronized Set<String> getAgents() {
-    return new TreeSet<String>(agents);
+  public synchronized Set<CmServerService> getAgents() {
+    return new HashSet<CmServerService>(agents);
   }
 
-  public synchronized Set<String> getNodes() {
-    return new TreeSet<String>(nodes);
+  public synchronized Set<CmServerService> getNodes() {
+    return new HashSet<CmServerService>(nodes);
   }
 
   public synchronized void setMounts(Set<String> mounts) {

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerCluster.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerCluster.java
@@ -31,6 +31,7 @@ import com.google.common.collect.Lists;
 
 public class CmServerCluster {
 
+  private String name;
   private String server;
   private boolean isParcel = true;
   private Set<CmServerService> agents = new HashSet<CmServerService>();
@@ -48,6 +49,10 @@ public class CmServerCluster {
       }
     }
     return true;
+  }
+
+  public synchronized String setName(String name) {
+    return this.name = name;
   }
 
   public synchronized boolean addServiceType(CmServerServiceType type) throws CmServerException {
@@ -150,6 +155,9 @@ public class CmServerCluster {
   }
 
   public synchronized String getServiceName(CmServerServiceType type) throws IOException {
+    if (type.equals(CmServerServiceType.CLUSTER) && name != null) {
+      return name;
+    }
     if (services.get(type) != null) {
       CmServerService service = services.get(type).iterator().next();
       if (service.getType().equals(type)) {

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerService.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerService.java
@@ -41,7 +41,7 @@ public class CmServerService implements Comparable<CmServerService> {
 
   private String toString;
 
-  public CmServerService(String name, String host, String ip, String ipInternal, CmServerServiceStatus status) {
+  protected CmServerService(String name, String host, String ip, String ipInternal, CmServerServiceStatus status) {
     if (name == null) {
       throw new IllegalArgumentException("Illegal argumnents passed to constructor");
     }
@@ -62,7 +62,7 @@ public class CmServerService implements Comparable<CmServerService> {
     this.status = status;
   }
 
-  public CmServerService(CmServerServiceType type, String tag, String qualifier, String host, String ip,
+  protected CmServerService(CmServerServiceType type, String tag, String qualifier, String host, String ip,
       String ipInternal, CmServerServiceStatus status) {
     if (type == null || tag == null || tag.contains(NAME_TOKEN_DELIM) || qualifier == null
         || qualifier.contains(NAME_TOKEN_DELIM)) {

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerService.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerService.java
@@ -20,7 +20,7 @@ package com.cloudera.whirr.cm.server;
 public class CmServerService implements Comparable<CmServerService> {
 
   public enum CmServerServiceStatus {
-    STARTING, STARTED, STOPPING, STOPPED, UNKNOWN
+    STARTING, STARTED, STOPPING, STOPPED, BUSY, UNKNOWN
   }
 
   public static final String NAME_TOKEN_DELIM = "_";

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerService.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerService.java
@@ -196,7 +196,7 @@ public class CmServerService implements Comparable<CmServerService> {
     return ip;
   }
 
-  public String geIpInternal() {
+  public String getIpInternal() {
     return ipInternal;
   }
 

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -163,7 +163,7 @@ public class CmServerImpl implements CmServer {
         public void execute() {
           for (ApiHost host : apiResourceRoot.getHostsResource().readHosts(DataView.SUMMARY).getHosts()) {
             services.add(new CmServerServiceBuilder().host(host.getHostId()).ip(host.getIpAddress())
-                .status(CmServerServiceStatus.STARTED).build());
+                .ipInternal(host.getIpAddress()).status(CmServerServiceStatus.STARTED).build());
           }
         }
       });
@@ -192,7 +192,9 @@ public class CmServerImpl implements CmServer {
       for (CmServerService serviceTmp : services) {
         if ((service.getHost() != null && service.getHost().equals(serviceTmp.getHost()))
             || (service.getIp() != null && service.getIp().equals(serviceTmp.getIp()))
-            || (service.geIpInternal() != null && service.geIpInternal().equals(serviceTmp.getIp()))) {
+            || (service.getIp() != null && service.getIp().equals(serviceTmp.getIpInternal()))
+            || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIp()))
+            || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIpInternal()))) {
           serviceFound = serviceTmp;
           break;
         }
@@ -216,7 +218,7 @@ public class CmServerImpl implements CmServer {
       List<CmServerService> services = getServiceHosts();
       for (CmServerService server : cluster.getAgents()) {
         if (getServiceHost(server, services) != null) {
-          clusterView.addAgent(server);
+          clusterView.addAgent(getServiceHost(server, services));
         }
       }
       if (isProvisioned(cluster)) {
@@ -841,6 +843,10 @@ public class CmServerImpl implements CmServer {
       apiRoleConfigGroups.add(apiRoleConfigGroup);
     }
     for (CmServerService subService : cluster.getServices(type)) {
+
+      System.err.println(subService);
+      System.err.println(services);
+
       String hostId = getServiceHost(subService, services).getHost();
       ApiRole apiRole = new ApiRole();
       apiRole.setName(subService.getName());

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -235,7 +235,7 @@ public class CmServerImpl implements CmServer {
           public void execute() throws IOException, CmServerException {
             Map<String, String> ips = new HashMap<String, String>();
             for (ApiService apiService : apiResourceRoot.getClustersResource().getServicesResource(getName(cluster))
-                .readServices(DataView.SUMMARY)) {
+                .readServices(DataView.SUMMARY)) {                           
               for (ApiRole apiRole : apiResourceRoot.getClustersResource().getServicesResource(getName(cluster))
                   .getRolesResource(apiService.getName()).readRoles()) {
                 if (!ips.containsKey(apiRole.getHostRef().getHostId())) {
@@ -269,13 +269,8 @@ public class CmServerImpl implements CmServer {
   @Override
   public CmServerService getService(final CmServerCluster cluster, final CmServerServiceType type)
       throws CmServerException {
-
-    CmServerCluster clusterView = getServices(cluster, type);
-    if (clusterView.isEmpty()) {
-      throw new CmServerException("Failed to find service matching type [" + type + "]");
-    }
-
-    return clusterView.getService(type);
+        
+    return  getServices(cluster, type).getService(type);
 
   }
 
@@ -285,18 +280,18 @@ public class CmServerImpl implements CmServer {
 
     final CmServerCluster clusterView = new CmServerCluster();
     try {
-
+      
       for (CmServerService service : getServices(cluster).getServices(CmServerServiceType.CLUSTER)) {
         if (type.equals(CmServerServiceType.CLUSTER) || type.equals(service.getType().getParent())
             || type.equals(service.getType())) {
           clusterView.addService(service);
         }
       }
-
+      
     } catch (Exception e) {
       throw new CmServerException("Failed to find services", e);
     }
-
+    
     return clusterView;
 
   }

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -81,7 +81,7 @@ public class CmServerImpl implements CmServer {
   private static final String CM_PARCEL_STAGE_ACTIVATED = "ACTIVATED";
 
   private static int API_POLL_PERIOD_MS = 500;
-  private static int API_POLL_PERIOD_BACKOFF_NUMBER = 5;
+  private static int API_POLL_PERIOD_BACKOFF_NUMBER = 4;
 
   private CmServerLog logger;
   final private RootResourceV3 apiResourceRoot;
@@ -232,9 +232,15 @@ public class CmServerImpl implements CmServer {
                   ips.put(apiRole.getHostRef().getHostId(),
                       apiResourceRoot.getHostsResource().readHost(apiRole.getHostRef().getHostId()).getIpAddress());
                 }
+                CmServerServiceStatus status = null;
+                try {
+                  status = CmServerServiceStatus.valueOf(apiRole.getRoleState().toString());
+                } catch (IllegalArgumentException exception) {
+                  status = CmServerServiceStatus.UNKNOWN;
+                }
                 clusterView.addService(new CmServerServiceBuilder().name(apiRole.getName())
                     .host(apiRole.getHostRef().getHostId()).ip(ips.get(apiRole.getHostRef().getHostId()))
-                    .status(CmServerServiceStatus.valueOf(apiRole.getRoleState().toString())).build());
+                    .status(status).build());
               }
             }
           }

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -998,6 +998,10 @@ public class CmServerImpl implements CmServer {
     while (true) {
       if (apiPollPeriods++ % apiPollPeriodLog == 0) {
         logger.logOperationInProgressAsync(label);
+        if (apiPollPeriodBackoffNumber-- == 0) {
+          apiPollPeriodLog += API_POLL_PERIOD_BACKOFF_INCRAMENT;
+          apiPollPeriodBackoffNumber = API_POLL_PERIOD_BACKOFF_NUMBER;
+        }
       }
       if (callback.poll()) {
         if (checkReturn && command != null
@@ -1007,10 +1011,6 @@ public class CmServerImpl implements CmServer {
         }
         logger.logOperationFinishedAsync(label);
         return commandReturn;
-      }
-      if (apiPollPeriodBackoffNumber-- == 0) {
-        apiPollPeriodLog += API_POLL_PERIOD_BACKOFF_INCRAMENT;
-        apiPollPeriodBackoffNumber = API_POLL_PERIOD_BACKOFF_NUMBER;
       }
       Thread.sleep(API_POLL_PERIOD_MS);
     }

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -190,13 +190,15 @@ public class CmServerImpl implements CmServer {
     try {
 
       for (CmServerService serviceTmp : services) {
-        if ((service.getHost() != null && service.getHost().equals(serviceTmp.getHost()))
-            || (service.getIp() != null && service.getIp().equals(serviceTmp.getIp()))
-            || (service.getIp() != null && service.getIp().equals(serviceTmp.getIpInternal()))
-            || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIp()))
-            || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIpInternal()))) {
-          serviceFound = serviceTmp;
-          break;
+        if (service.getType().equals(serviceTmp.getType())) {
+          if ((service.getHost() != null && service.getHost().equals(serviceTmp.getHost()))
+              || (service.getIp() != null && service.getIp().equals(serviceTmp.getIp()))
+              || (service.getIp() != null && service.getIp().equals(serviceTmp.getIpInternal()))
+              || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIp()))
+              || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIpInternal()))) {
+            serviceFound = serviceTmp;
+            break;
+          }
         }
       }
 
@@ -242,7 +244,7 @@ public class CmServerImpl implements CmServer {
                 }
                 clusterView.addService(new CmServerServiceBuilder().name(apiRole.getName())
                     .host(apiRole.getHostRef().getHostId()).ip(ips.get(apiRole.getHostRef().getHostId()))
-                    .status(status).build());
+                    .ipInternal(ips.get(apiRole.getHostRef().getHostId())).status(status).build());
               }
             }
           }

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -81,7 +81,7 @@ public class CmServerImpl implements CmServer {
   private static final String CM_PARCEL_STAGE_ACTIVATED = "ACTIVATED";
 
   private static int API_POLL_PERIOD_MS = 500;
-  private static int API_POLL_PERIOD_BACKOFF_NUMBER = 4;
+  private static int API_POLL_PERIOD_BACKOFF_NUMBER = 3;
 
   private CmServerLog logger;
   final private RootResourceV3 apiResourceRoot;
@@ -190,15 +190,15 @@ public class CmServerImpl implements CmServer {
     try {
 
       for (CmServerService serviceTmp : services) {
-        if (service.getType().equals(serviceTmp.getType())) {
-          if ((service.getHost() != null && service.getHost().equals(serviceTmp.getHost()))
-              || (service.getIp() != null && service.getIp().equals(serviceTmp.getIp()))
-              || (service.getIp() != null && service.getIp().equals(serviceTmp.getIpInternal()))
-              || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIp()))
-              || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIpInternal()))) {
-            serviceFound = serviceTmp;
-            break;
-          }
+        if ((service.getHost() != null && service.getHost().equals(serviceTmp.getHost()))
+            || (service.getHost() != null && service.getHost().equals(serviceTmp.getIp()))
+            || (service.getHost() != null && service.getHost().equals(serviceTmp.getIpInternal()))
+            || (service.getIp() != null && service.getIp().equals(serviceTmp.getIp()))
+            || (service.getIp() != null && service.getIp().equals(serviceTmp.getIpInternal()))
+            || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIp()))
+            || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIpInternal()))) {
+          serviceFound = serviceTmp;
+          break;
         }
       }
 
@@ -846,8 +846,10 @@ public class CmServerImpl implements CmServer {
     }
     for (CmServerService subService : cluster.getServices(type)) {
 
-      System.err.println(subService);
-      System.err.println(services);
+      if (getServiceHost(subService, services) == null) {
+        System.err.println(subService);
+        System.err.println(services);
+      }
 
       String hostId = getServiceHost(subService, services).getHost();
       ApiRole apiRole = new ApiRole();

--- a/src/main/resources/META-INF/services/org.apache.whirr.command.Command
+++ b/src/main/resources/META-INF/services/org.apache.whirr.command.Command
@@ -19,3 +19,4 @@ com.cloudera.whirr.cm.cmd.CmServerDownloadConfigCommand
 com.cloudera.whirr.cm.cmd.CmServerCreateServicesCommand
 com.cloudera.whirr.cm.cmd.CmServerDestroyServicesCommand
 com.cloudera.whirr.cm.cmd.CmServerListServicesCommand
+com.cloudera.whirr.cm.cmd.CmServerCleanClusterCommand

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
@@ -40,7 +40,7 @@ import com.google.common.collect.ImmutableSet;
 public class BaseTestIntegration implements BaseTest {
 
   // The CM Server and database host/IP and port
-  protected static String CM_IP = getSystemProperty("whirr.test.cm.ip", "37.188.115.30");
+  protected static String CM_IP = getSystemProperty("whirr.test.cm.ip", "31.222.181.138");
   protected static int CM_PORT = Integer.valueOf(getSystemProperty("whirr.test.cm.port", "7180"));
 
   // The CM Server config to be uploaded

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
@@ -40,7 +40,8 @@ import com.google.common.collect.ImmutableSet;
 public class BaseTestIntegration implements BaseTest {
 
   // The CM Server and database host/IP and port
-  protected static String CM_HOST_OR_IP = getSystemProperty("whirr.test.cm.host", "54.224.157.241");
+  protected static String CM_IP = getSystemProperty("whirr.test.cm.ip", "54.224.157.241");
+  protected static String CM_IP_PRIVATE = getSystemProperty("whirr.test.cm.host-ip-private", "10.214.14.227");
   protected static int CM_PORT = Integer.valueOf(getSystemProperty("whirr.test.cm.port", "7180"));
 
   // The CM Server config to be uploaded
@@ -57,42 +58,42 @@ public class BaseTestIntegration implements BaseTest {
   @BeforeClass
   public static void initialiseCluster() throws CmServerException {
     cluster = new CmServerCluster();
-    Assert.assertNotNull(serverBootstrap = new CmServerFactory().getCmServer(CM_HOST_OR_IP, CM_PORT,
-        CmConstants.CM_USER, CmConstants.CM_PASSWORD, new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API_TEST,
-            false)));
+    Assert.assertNotNull(serverBootstrap = new CmServerFactory().getCmServer(CM_IP, CM_PORT, CmConstants.CM_USER,
+        CmConstants.CM_PASSWORD, new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API_TEST, false)));
     Assert.assertTrue(serverBootstrap.initialise(CM_CONFIG).size() > 0);
     hosts = new HashSet<String>();
     for (CmServerService service : serverBootstrap.getServiceHosts()) {
-      hosts.add(service.getHost());
+      hosts.add(service.getIp());
       cluster.addAgent(service);
     }
     Assert.assertFalse(hosts.isEmpty());
     Assert.assertTrue("Integration test cluster requires at least 4 nodes", hosts.size() >= 4);
     clusterSize = hosts.size();
-    if (!hosts.remove(CM_HOST_OR_IP)) {
-      hosts.remove(hosts.iterator().next());
+    if (!hosts.remove(CM_IP) && !hosts.remove(CM_IP_PRIVATE)) {
+      throw new CmServerException("Could not find integration server with public IP [" + CM_IP + "] and private IP ["
+          + CM_IP_PRIVATE + "] in host IP list " + hosts);
     }
     String[] hostSlaves = hosts.toArray(new String[hosts.size()]);
-    cluster.setServer(CM_HOST_OR_IP);
+    cluster.setServer(CM_IP);
     cluster.setMounts(ImmutableSet.<String> builder().add("/data/" + CLUSTER_TAG).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HIVE_METASTORE).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HUE_SERVER).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HUE_BEESWAX_SERVER).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.OOZIE_SERVER).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HBASE_MASTER).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_NAMENODE).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_SECONDARY_NAMENODE).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.MAPREDUCE_JOB_TRACKER).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.IMPALA_STATE_STORE).tag(CLUSTER_TAG)
-        .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());
+        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
     for (int i = 0; i < hostSlaves.length; i++) {
       cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HBASE_REGIONSERVER).tag(CLUSTER_TAG)
           .qualifier("" + (i + 1)).host(hostSlaves[i]).build());

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
@@ -40,8 +40,7 @@ import com.google.common.collect.ImmutableSet;
 public class BaseTestIntegration implements BaseTest {
 
   // The CM Server and database host/IP and port
-  protected static String CM_IP = getSystemProperty("whirr.test.cm.ip", "54.224.157.241");
-  protected static String CM_IP_PRIVATE = getSystemProperty("whirr.test.cm.host-ip-private", "10.214.14.227");
+  protected static String CM_IP = getSystemProperty("whirr.test.cm.ip", "37.188.115.30");
   protected static int CM_PORT = Integer.valueOf(getSystemProperty("whirr.test.cm.port", "7180"));
 
   // The CM Server config to be uploaded
@@ -63,50 +62,50 @@ public class BaseTestIntegration implements BaseTest {
     Assert.assertTrue(serverBootstrap.initialise(CM_CONFIG).size() > 0);
     hosts = new HashSet<String>();
     for (CmServerService service : serverBootstrap.getServiceHosts()) {
-      hosts.add(service.getIp());
+      hosts.add(service.getIpInternal());
       cluster.addAgent(service);
     }
     Assert.assertFalse(hosts.isEmpty());
     Assert.assertTrue("Integration test cluster requires at least 4 nodes", hosts.size() >= 4);
     clusterSize = hosts.size();
-    if (!hosts.remove(CM_IP) && !hosts.remove(CM_IP_PRIVATE)) {
-      throw new CmServerException("Could not find integration server with public IP [" + CM_IP + "] and private IP ["
-          + CM_IP_PRIVATE + "] in host IP list " + hosts);
+    if (!hosts.remove(CM_IP)) {
+      throw new CmServerException("Could not find integration server with public IP [" + CM_IP + "] in host IP list "
+          + hosts);
     }
     String[] hostSlaves = hosts.toArray(new String[hosts.size()]);
     cluster.setServer(CM_IP);
     cluster.setMounts(ImmutableSet.<String> builder().add("/data/" + CLUSTER_TAG).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HIVE_METASTORE).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HUE_SERVER).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HUE_BEESWAX_SERVER).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.OOZIE_SERVER).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HBASE_MASTER).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_NAMENODE).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_SECONDARY_NAMENODE).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.MAPREDUCE_JOB_TRACKER).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.IMPALA_STATE_STORE).tag(CLUSTER_TAG)
-        .qualifier("1").ip(CM_IP).ipInternal(CM_IP_PRIVATE).build());
+        .qualifier("1").ip(CM_IP).build());
     for (int i = 0; i < hostSlaves.length; i++) {
       cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HBASE_REGIONSERVER).tag(CLUSTER_TAG)
-          .qualifier("" + (i + 1)).host(hostSlaves[i]).build());
+          .qualifier("" + (i + 1)).ip(hostSlaves[i]).build());
       cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.MAPREDUCE_TASK_TRACKER).tag(CLUSTER_TAG)
-          .qualifier("" + (i + 1)).host(hostSlaves[i]).build());
+          .qualifier("" + (i + 1)).ip(hostSlaves[i]).build());
       cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_DATANODE).tag(CLUSTER_TAG)
-          .qualifier("" + (i + 1)).host(hostSlaves[i]).build());
+          .qualifier("" + (i + 1)).ip(hostSlaves[i]).build());
       cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.ZOOKEEPER_SERVER).tag(CLUSTER_TAG)
-          .qualifier("" + (i + 1)).host(hostSlaves[i]).build());
+          .qualifier("" + (i + 1)).ip(hostSlaves[i]).build());
       cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.IMPALA_DAEMON).tag(CLUSTER_TAG)
-          .qualifier("" + (i + 1)).host(hostSlaves[i]).build());
+          .qualifier("" + (i + 1)).ip(hostSlaves[i]).build());
       cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.FLUME_AGENT).tag(CLUSTER_TAG)
-          .qualifier("" + (i + 1)).host(hostSlaves[i]).build());
+          .qualifier("" + (i + 1)).ip(hostSlaves[i]).build());
     }
   }
 

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
@@ -40,7 +40,7 @@ import com.google.common.collect.ImmutableSet;
 public class BaseTestIntegration implements BaseTest {
 
   // The CM Server and database host/IP and port
-  protected static String CM_HOST_OR_IP = getSystemProperty("whirr.test.cm.host", "37.188.123.45");
+  protected static String CM_HOST_OR_IP = getSystemProperty("whirr.test.cm.host", "54.242.201.142");
   protected static int CM_PORT = Integer.valueOf(getSystemProperty("whirr.test.cm.port", "7180"));
 
   // The CM Server config to be uploaded
@@ -56,6 +56,7 @@ public class BaseTestIntegration implements BaseTest {
 
   @BeforeClass
   public static void initialiseCluster() throws CmServerException {
+    cluster = new CmServerCluster();
     Assert.assertNotNull(serverBootstrap = new CmServerFactory().getCmServer(CM_HOST_OR_IP, CM_PORT,
         CmConstants.CM_USER, CmConstants.CM_PASSWORD, new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API_TEST,
             false)));
@@ -63,6 +64,7 @@ public class BaseTestIntegration implements BaseTest {
     hosts = new HashSet<String>();
     for (CmServerService service : serverBootstrap.getServiceHosts()) {
       hosts.add(service.getHost());
+      cluster.addAgent(service);
     }
     Assert.assertFalse(hosts.isEmpty());
     Assert.assertTrue("Integration test cluster requires at least 4 nodes", hosts.size() >= 4);
@@ -71,11 +73,7 @@ public class BaseTestIntegration implements BaseTest {
       hosts.remove(hosts.iterator().next());
     }
     String[] hostSlaves = hosts.toArray(new String[hosts.size()]);
-    cluster = new CmServerCluster();
     cluster.setServer(CM_HOST_OR_IP);
-    for (String agent : hosts) {
-      cluster.addAgent(agent);
-    }
     cluster.setMounts(ImmutableSet.<String> builder().add("/data/" + CLUSTER_TAG).build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HIVE_METASTORE).tag(CLUSTER_TAG)
         .qualifier("1").host(CM_HOST_OR_IP).ip(CM_HOST_OR_IP).build());

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
@@ -40,7 +40,7 @@ import com.google.common.collect.ImmutableSet;
 public class BaseTestIntegration implements BaseTest {
 
   // The CM Server and database host/IP and port
-  protected static String CM_HOST_OR_IP = getSystemProperty("whirr.test.cm.host", "54.242.201.142");
+  protected static String CM_HOST_OR_IP = getSystemProperty("whirr.test.cm.host", "54.224.157.241");
   protected static int CM_PORT = Integer.valueOf(getSystemProperty("whirr.test.cm.port", "7180"));
 
   // The CM Server config to be uploaded

--- a/src/test/java/com/cloudera/whirr/cm/cmd/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/CmServerCommandTest.java
@@ -41,8 +41,8 @@ import com.cloudera.whirr.cm.handler.CmServerHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhHdfsDataNodeHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhHdfsNameNodeHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhHdfsSecondaryNameNodeHandler;
-import com.cloudera.whirr.cm.server.CmServerCluster;
 import com.cloudera.whirr.cm.server.CmServerBuilder;
+import com.cloudera.whirr.cm.server.CmServerCluster;
 import com.cloudera.whirr.cm.server.CmServerServiceType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -73,7 +73,8 @@ public class CmServerCommandTest extends BaseTestCommand {
 
     BaseCommandCmServer clusterCommand = new BaseCommandCmServer("name", "description", factory, stateStoreFactory) {
       @Override
-      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand) throws Exception {
+      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand)
+          throws Exception {
         return 0;
       }
     };
@@ -99,7 +100,8 @@ public class CmServerCommandTest extends BaseTestCommand {
 
     BaseCommandCmServer clusterCommand = new BaseCommandCmServer("name", "description", factory, stateStoreFactory) {
       @Override
-      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand) throws Exception {
+      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand)
+          throws Exception {
         assertThat(cluster.getServices(CmServerServiceType.CLUSTER).size(), is(rolesNumberCmCdh));
         assertThat(true, is(serverCommand != null));
         return 0;
@@ -129,7 +131,8 @@ public class CmServerCommandTest extends BaseTestCommand {
 
     BaseCommandCmServer clusterCommand = new BaseCommandCmServer("name", "description", factory, stateStoreFactory) {
       @Override
-      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand) throws Exception {
+      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand)
+          throws Exception {
         assertThat(cluster.getServices(CmServerServiceType.CLUSTER).size(), is(rolesNumberCmCdh));
         assertThat(true, is(serverCommand != null));
         return 0;
@@ -147,6 +150,35 @@ public class CmServerCommandTest extends BaseTestCommand {
   }
 
   @Test
+  public void testBaseCommandCmServerHdfsRolesClusterName() throws Exception {
+
+    final String name = "My Cluster - Yay for me!";
+    final int rolesNumberCmCdh = initialiseCluster(new String[][] {
+        { CmServerHandler.ROLE, CmAgentHandler.ROLE, CmCdhHdfsNameNodeHandler.ROLE,
+            CmCdhHdfsSecondaryNameNodeHandler.ROLE }, { CmAgentHandler.ROLE, CmCdhHdfsDataNodeHandler.ROLE } });
+
+    BaseCommandCmServer clusterCommand = new BaseCommandCmServer("name", "description", factory, stateStoreFactory) {
+      @Override
+      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand)
+          throws Exception {
+        assertThat(cluster.getServiceName(CmServerServiceType.CLUSTER), is(name));
+        assertThat(cluster.getServices(CmServerServiceType.CLUSTER).size(), is(rolesNumberCmCdh));
+        assertThat(true, is(serverCommand != null));
+        return 0;
+      }
+    };
+
+    Map<String, File> keys = KeyPair.generateTemporaryFiles();
+    int rc = clusterCommand.run(null, System.out, System.err, Lists.newArrayList("--instance-templates", "1 noop",
+        "--service-name", "test-service", "--cluster-name", "test-cluster", "--identity", "myusername", "--name", name,
+        "--quiet", "--private-key-file", keys.get("private").getAbsolutePath()));
+
+    assertThat(rc, is(0));
+    verify(factory).create("test-service");
+
+  }
+
+  @Test
   public void testBaseCommandCmServerHdfsRolesFilteredEroneous() throws Exception {
 
     initialiseCluster(new String[][] {
@@ -155,7 +187,8 @@ public class CmServerCommandTest extends BaseTestCommand {
 
     BaseCommandCmServer clusterCommand = new BaseCommandCmServer("name", "description", factory, stateStoreFactory) {
       @Override
-      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand) throws Exception {
+      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand)
+          throws Exception {
         assertThat(cluster.getServices(CmServerServiceType.CLUSTER).size(), is(1));
         assertThat(true, is(serverCommand != null));
         return 0;
@@ -189,7 +222,8 @@ public class CmServerCommandTest extends BaseTestCommand {
       }
 
       @Override
-      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand) throws Exception {
+      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand)
+          throws Exception {
         assertThat(cluster.getServices(CmServerServiceType.CLUSTER).size(), is(1));
         assertThat(true, is(serverCommand != null));
         return 0;
@@ -220,7 +254,8 @@ public class CmServerCommandTest extends BaseTestCommand {
       }
 
       @Override
-      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand) throws Exception {
+      public int run(ClusterSpec specification, CmServerCluster cluster, CmServerBuilder serverCommand)
+          throws Exception {
         assertThat(cluster.getServices(CmServerServiceType.CLUSTER).size(), is(3));
         assertThat(true, is(serverCommand != null));
         return 0;

--- a/src/test/java/com/cloudera/whirr/cm/cmd/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/CmServerCommandTest.java
@@ -51,7 +51,7 @@ public class CmServerCommandTest extends BaseTestCommand {
 
   private static final List<Class<? extends BaseCommand>> COMMANDS = ImmutableList.<Class<? extends BaseCommand>> of(
       CmServerDownloadConfigCommand.class, CmServerCreateServicesCommand.class, CmServerDestroyServicesCommand.class,
-      CmServerListServicesCommand.class);
+      CmServerListServicesCommand.class, CmServerCleanClusterCommand.class);
 
   @Test
   public void testCommandServiceLoader() throws Exception {

--- a/src/test/java/com/cloudera/whirr/cm/cmd/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/CmServerCommandTest.java
@@ -170,8 +170,8 @@ public class CmServerCommandTest extends BaseTestCommand {
 
     Map<String, File> keys = KeyPair.generateTemporaryFiles();
     int rc = clusterCommand.run(null, System.out, System.err, Lists.newArrayList("--instance-templates", "1 noop",
-        "--service-name", "test-service", "--cluster-name", "test-cluster", "--identity", "myusername", "--name", name,
-        "--quiet", "--private-key-file", keys.get("private").getAbsolutePath()));
+        "--service-name", "test-service", "--cluster-name", "test-cluster", "--identity", "myusername",
+        "--cm-cluster-name", name, "--quiet", "--private-key-file", keys.get("private").getAbsolutePath()));
 
     assertThat(rc, is(0));
     verify(factory).create("test-service");

--- a/src/test/java/com/cloudera/whirr/cm/cmd/integration/BaseTestIntegrationCommand.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/integration/BaseTestIntegrationCommand.java
@@ -34,11 +34,11 @@ public abstract class BaseTestIntegrationCommand extends BaseTestIntegration {
   @Before
   public void provisionCluster() throws Exception {
     super.provisionCluster();
-    command = new CmServerBuilder().host(CM_HOST_OR_IP).cluster(cluster).client(DIR_CLIENT_CONFIG.getAbsolutePath());
+    command = new CmServerBuilder().host(CM_IP).cluster(cluster).client(DIR_CLIENT_CONFIG.getAbsolutePath());
     Configuration configuration = new PropertiesConfiguration();
-    configuration.setProperty(CONFIG_WHIRR_USER, CLUSTER_USER);
-    configuration.setProperty(CONFIG_WHIRR_PRIV_KEY, FILE_KEY_PRIVATE.getAbsolutePath());
-    configuration.setProperty(CONFIG_WHIRR_PUB_KEY, FILE_KEY_PUBLIC.getAbsolutePath());
+    configuration.setProperty(ClusterSpec.Property.CLUSTER_USER.getConfigName(), CLUSTER_USER);
+    configuration.setProperty(ClusterSpec.Property.PRIVATE_KEY_FILE.getConfigName(), FILE_KEY_PRIVATE.getAbsolutePath());
+    configuration.setProperty(ClusterSpec.Property.PUBLIC_KEY_FILE.getConfigName(), FILE_KEY_PUBLIC.getAbsolutePath());
     specification = new ClusterSpec(configuration);
   }
 

--- a/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
@@ -25,6 +25,7 @@ import com.cloudera.whirr.cm.cmd.CmServerCreateServicesCommand;
 import com.cloudera.whirr.cm.cmd.CmServerDestroyServicesCommand;
 import com.cloudera.whirr.cm.cmd.CmServerDownloadConfigCommand;
 import com.cloudera.whirr.cm.cmd.CmServerListServicesCommand;
+import com.cloudera.whirr.cm.server.CmServerServiceType;
 
 public class CmServerCommandTest extends BaseTestIntegrationCommand {
 
@@ -52,6 +53,7 @@ public class CmServerCommandTest extends BaseTestIntegrationCommand {
   @Test
   public void testCommandDownloadConfig() throws Exception {
     Assert.assertTrue(serverBootstrap.configure(cluster));
+    cluster.setName(cluster.getServiceName(CmServerServiceType.CLUSTER));
     Assert.assertEquals(0, new CmServerDownloadConfigCommand(null, null).run(specification, cluster, command));
   }
 

--- a/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
@@ -72,6 +72,8 @@ public class CmServerCommandTest extends BaseTestIntegrationCommand {
     Assert.assertEquals(0, new CmServerDestroyServicesCommand(null, null).run(specification, cluster, command));
     Assert.assertEquals(0, new CmServerCreateServicesCommand(null, null).run(specification, cluster, command));
     Assert.assertEquals(0, new CmServerListServicesCommand(null, null).run(specification, cluster, command));
+    Assert.assertEquals(0, new CmServerDestroyServicesCommand(null, null).run(specification, cluster, command));
+    Assert.assertEquals(-1, new CmServerDestroyServicesCommand(null, null).run(specification, cluster, command));
   }
 
 }

--- a/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
@@ -20,6 +20,7 @@ package com.cloudera.whirr.cm.cmd.integration;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.cloudera.whirr.cm.cmd.CmServerCleanClusterCommand;
 import com.cloudera.whirr.cm.cmd.CmServerCreateServicesCommand;
 import com.cloudera.whirr.cm.cmd.CmServerDestroyServicesCommand;
 import com.cloudera.whirr.cm.cmd.CmServerDownloadConfigCommand;
@@ -43,6 +44,11 @@ public class CmServerCommandTest extends BaseTestIntegrationCommand {
     Assert.assertEquals(0, new CmServerDestroyServicesCommand(null, null).run(specification, cluster, command));
   }
 
+  @Test
+  public void testCommandCleanCluster() throws Exception {
+    Assert.assertEquals(0, new CmServerCleanClusterCommand(null, null).run(specification, cluster, command));
+  }
+  
   @Test
   public void testCommandDownloadConfig() throws Exception {
     Assert.assertTrue(serverBootstrap.configure(cluster));

--- a/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
@@ -56,7 +56,7 @@ public class CmServerCommandTest extends BaseTestIntegrationCommand {
   }
 
   @Test
-  public void testListServicesConfig() throws Exception {
+  public void testListServices() throws Exception {
     Assert.assertTrue(serverBootstrap.configure(cluster));
     Assert.assertEquals(0, new CmServerListServicesCommand(null, null).run(specification, cluster, command));
   }

--- a/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/integration/CmServerCommandTest.java
@@ -44,11 +44,6 @@ public class CmServerCommandTest extends BaseTestIntegrationCommand {
     Assert.assertTrue(serverBootstrap.configure(cluster));
     Assert.assertEquals(0, new CmServerDestroyServicesCommand(null, null).run(specification, cluster, command));
   }
-
-  @Test
-  public void testCommandCleanCluster() throws Exception {
-    Assert.assertEquals(0, new CmServerCleanClusterCommand(null, null).run(specification, cluster, command));
-  }
   
   @Test
   public void testCommandDownloadConfig() throws Exception {
@@ -78,4 +73,9 @@ public class CmServerCommandTest extends BaseTestIntegrationCommand {
     Assert.assertEquals(-1, new CmServerDestroyServicesCommand(null, null).run(specification, cluster, command));
   }
 
+  @Test
+  public void testCommandCleanCluster() throws Exception {
+    Assert.assertEquals(0, new CmServerCleanClusterCommand(null, null).run(specification, cluster, command));
+  }
+  
 }

--- a/src/test/java/com/cloudera/whirr/cm/handler/BaseTestHandler.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/BaseTestHandler.java
@@ -190,7 +190,7 @@ public abstract class BaseTestHandler extends BaseServiceDryRunTest implements B
   public ClusterSpec newClusterSpecForProperties(Map<String, String> properties) throws IOException,
       ConfigurationException, JSchException {
     ClusterSpec clusterSpec = super.newClusterSpecForProperties(ImmutableMap.<String, String> builder()
-        .putAll(properties).put(CONFIG_WHIRR_USER, CLUSTER_USER).put(CONFIG_WHIRR_NAME, CONFIG_WHIRR_NAME_DEFAULT)
+        .putAll(properties).put(ClusterSpec.Property.CLUSTER_USER.getConfigName(), CLUSTER_USER).put(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), CONFIG_WHIRR_NAME_DEFAULT)
         .build());
     clusterSpec.setPrivateKey(FILE_KEY_PRIVATE);
     clusterSpec.setPublicKey(FILE_KEY_PUBLIC);

--- a/src/test/java/com/cloudera/whirr/cm/handler/BaseTestHandler.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/BaseTestHandler.java
@@ -238,7 +238,7 @@ public abstract class BaseTestHandler extends BaseServiceDryRunTest implements B
 
   private static Object any(Object value) {
     new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API, false).logOperation(
-        WordUtils.capitalize(Thread.currentThread().getStackTrace()[3].getMethodName()), new CmServerLogSyncCommand() {
+        WordUtils.capitalize(Thread.currentThread().getStackTrace()[4].getMethodName()), new CmServerLogSyncCommand() {
           @Override
           public void execute() throws Exception {
           }

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
@@ -199,7 +199,8 @@ public class CmServerHandlerTest extends BaseTestHandler {
       ClusterSpec clusterSpec = newClusterSpecForProperties(ImmutableMap.of("whirr.instance-templates", "1 "
           + CmServerHandler.ROLE + ",1 " + CmAgentHandler.ROLE + ",1 " + CmAgentHandler.ROLE + "+"
           + CmCdhHdfsNameNodeHandler.ROLE));
-      clusterSpec.getConfiguration().setProperty(CONFIG_WHIRR_NAME, "some_cluster_name");
+      clusterSpec.getConfiguration()
+          .setProperty(ClusterSpec.Property.CLUSTER_NAME.getConfigName(), "some_cluster_name");
       Assert.assertNotNull(launchWithClusterSpec(clusterSpec));
     } catch (Exception e) {
       caught = true;

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
@@ -96,22 +96,15 @@ public class CmServerHandlerTest extends BaseTestHandler {
 
   @Test
   public void testNodesAndAgentsAndCluster() throws Exception {
-    Assert
-        .assertNotNull(launchWithClusterSpec(newClusterSpecForProperties(ImmutableMap
-            .of("whirr.instance-templates",
-                WHIRR_INSTANCE_TEMPLATE_ALL,
-                CONFIG_WHIRR_CM_PREFIX + "REMOTE_PARCEL_REPO_URLS",
-                "http://10.178.197.160/tmph3l7m2vv103/cloudera-repos/cdh4/parcels/4.2.0.10/\\,http://10.178.197.160/tmph3l7m2vv103/cloudera-repos/impala/parcels/0.6.109/"))));
+    Assert.assertNotNull(launchWithClusterSpec(newClusterSpecForProperties(ImmutableMap.of("whirr.instance-templates",
+        WHIRR_INSTANCE_TEMPLATE_ALL))));
     Assert.assertTrue(countersAssertAndReset(27, 27, 27, 0));
   }
 
   @Test
   public void testNodesAndAgentsAndClusterLifecycle() throws Exception {
-    ClusterSpec clusterSpec = newClusterSpecForProperties(ImmutableMap
-        .of("whirr.instance-templates",
-            WHIRR_INSTANCE_TEMPLATE_ALL,
-            CONFIG_WHIRR_CM_PREFIX + "REMOTE_PARCEL_REPO_URLS",
-            "http://10.178.197.160/tmph3l7m2vv103/cloudera-repos/cdh4/parcels/4.2.0.10/\\,http://10.178.197.160/tmph3l7m2vv103/cloudera-repos/impala/parcels/0.6.109/"));
+    ClusterSpec clusterSpec = newClusterSpecForProperties(ImmutableMap.of("whirr.instance-templates",
+        WHIRR_INSTANCE_TEMPLATE_ALL));
     ClusterController controller = getController(clusterSpec);
     Cluster cluster = launchWithClusterSpecAndWithController(clusterSpec, controller);
     Assert.assertNotNull(cluster);
@@ -126,11 +119,8 @@ public class CmServerHandlerTest extends BaseTestHandler {
 
   @Test
   public void testNodesAndAgentsAndClusterLifecycleFilteredHdfs() throws Exception {
-    ClusterSpec clusterSpec = newClusterSpecForProperties(ImmutableMap
-        .of("whirr.instance-templates",
-            WHIRR_INSTANCE_TEMPLATE_ALL,
-            CONFIG_WHIRR_CM_PREFIX + "REMOTE_PARCEL_REPO_URLS",
-            "http://10.178.197.160/tmph3l7m2vv103/cloudera-repos/cdh4/parcels/4.2.0.10/\\,http://10.178.197.160/tmph3l7m2vv103/cloudera-repos/impala/parcels/0.6.109/"));
+    ClusterSpec clusterSpec = newClusterSpecForProperties(ImmutableMap.of("whirr.instance-templates",
+        WHIRR_INSTANCE_TEMPLATE_ALL));
     Set<String> roles = BaseCommandCmServer.filterRoles(CmCdhHdfsNameNodeHandler.ROLE);
     ClusterController controller = getController(clusterSpec);
     Cluster cluster = launchWithClusterSpecAndWithController(clusterSpec, controller);
@@ -146,13 +136,8 @@ public class CmServerHandlerTest extends BaseTestHandler {
 
   @Test
   public void testNodesAndAgentsAndClusterNotAuto() throws Exception {
-    Assert
-        .assertNotNull(launchWithClusterSpec(newClusterSpecForProperties(ImmutableMap
-            .of("whirr.instance-templates",
-                WHIRR_INSTANCE_TEMPLATE_ALL,
-                CONFIG_WHIRR_CM_PREFIX + "REMOTE_PARCEL_REPO_URLS",
-                "http://10.178.197.160/tmph3l7m2vv103/cloudera-repos/cdh4/parcels/4.2.0.10/\\,http://10.178.197.160/tmph3l7m2vv103/cloudera-repos/impala/parcels/0.6.109/",
-                CONFIG_WHIRR_AUTO_VARIABLE, Boolean.FALSE.toString()))));
+    Assert.assertNotNull(launchWithClusterSpec(newClusterSpecForProperties(ImmutableMap.of("whirr.instance-templates",
+        WHIRR_INSTANCE_TEMPLATE_ALL, CONFIG_WHIRR_AUTO_VARIABLE, Boolean.FALSE.toString()))));
   }
 
   @Test

--- a/src/test/java/com/cloudera/whirr/cm/server/CmServerClusterTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/CmServerClusterTest.java
@@ -33,7 +33,7 @@ public class CmServerClusterTest extends BaseTestServer {
   public void setupCluster() throws CmServerException {
     cluster = new CmServerCluster();
     cluster.setServer("some-host");
-    cluster.addAgent("some-host");
+    cluster.addAgent(new CmServerServiceBuilder().host("some-host").build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_DATANODE).tag(CLUSTER_TAG)
         .qualifier("2").host("host-2").build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_NAMENODE).tag(CLUSTER_TAG)
@@ -114,7 +114,7 @@ public class CmServerClusterTest extends BaseTestServer {
     Assert.assertTrue(cluster.isEmpty());
     cluster.setServer("some-host");
     Assert.assertTrue(cluster.isEmpty());
-    cluster.addAgent("some-host");
+    cluster.addAgent(new CmServerServiceBuilder().host("some-host").build());
     Assert.assertFalse(cluster.isEmpty());
   }
 

--- a/src/test/java/com/cloudera/whirr/cm/server/CmServerClusterTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/CmServerClusterTest.java
@@ -223,6 +223,8 @@ public class CmServerClusterTest extends BaseTestServer {
     Assert.assertEquals(CLUSTER_TAG + CmServerService.NAME_TOKEN_DELIM
         + CmServerServiceType.CLUSTER.toString().toLowerCase() + CmServerService.NAME_TOKEN_DELIM + "1",
         cluster.getServiceName(CmServerServiceType.CLUSTER));
+    Assert.assertEquals(cluster.setName("My Cluster - Against Conventions!"),
+        cluster.getServiceName(CmServerServiceType.CLUSTER));
     Assert.assertEquals(CLUSTER_TAG + CmServerService.NAME_TOKEN_DELIM
         + CmServerServiceType.HDFS.toString().toLowerCase() + CmServerService.NAME_TOKEN_DELIM + "1",
         cluster.getServiceName(CmServerServiceType.HDFS));

--- a/src/test/java/com/cloudera/whirr/cm/server/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/CmServerCommandTest.java
@@ -30,7 +30,7 @@ public class CmServerCommandTest extends BaseTestServer {
   public void setupCluster() throws CmServerException {
     cluster = new CmServerCluster();
     cluster.setServer("some-host");
-    cluster.addAgent("some-host");
+    cluster.addAgent(new CmServerServiceBuilder().host("some-host").build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_NAMENODE).tag(CLUSTER_TAG)
         .qualifier("1").host("host-1").build());
     cluster.addService(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_SECONDARY_NAMENODE).tag(CLUSTER_TAG)

--- a/src/test/java/com/cloudera/whirr/cm/server/integration/BaseTestIntegrationServer.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/integration/BaseTestIntegrationServer.java
@@ -33,7 +33,7 @@ public class BaseTestIntegrationServer extends BaseTestIntegration {
 
   @BeforeClass
   public static void initialiseServer() throws CmServerException {
-    Assert.assertNotNull(server = new CmServerFactory().getCmServer(CM_HOST_OR_IP, CM_PORT, CmConstants.CM_USER,
+    Assert.assertNotNull(server = new CmServerFactory().getCmServer(CM_IP, CM_PORT, CmConstants.CM_USER,
         CmConstants.CM_PASSWORD, new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API, false)));
   }
 

--- a/src/test/java/com/cloudera/whirr/cm/server/integration/CmServerClusterTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/integration/CmServerClusterTest.java
@@ -55,23 +55,10 @@ public class CmServerClusterTest extends BaseTestIntegrationServer {
         server.getServiceHost(
             new CmServerServiceBuilder().host("some-rubbish").ip("192.168.1.89")
                 .ipInternal(serviceHosts.get(2).getIp()).status(CmServerServiceStatus.UNKNOWN).build()).getHost());
-    boolean caught = false;
-    try {
-      Assert.assertEquals(
-          serviceHosts.get(2).getHost(),
-          server.getServiceHost(
-              new CmServerServiceBuilder().host("some-rubbish").ip("192.168.1.89").ipInternal("192.168.1.90")
-                  .status(CmServerServiceStatus.UNKNOWN).build()).getHost());
-    } catch (CmServerException e) {
-      caught = true;
-    }
-    Assert.assertTrue(caught);
     Assert.assertEquals(
-        serviceHosts.get(2).getHost(),
-        server.getServiceHost(
-            new CmServerServiceBuilder().host("some-rubbish").ip("192.168.1.89")
-                .ipInternal(serviceHosts.get(2).getIp()).status(CmServerServiceStatus.UNKNOWN).build(), serviceHosts)
-            .getHost());
+        null,
+        server.getServiceHost(new CmServerServiceBuilder().host("some-rubbish").ip("192.168.1.89")
+            .ipInternal("192.168.1.90").status(CmServerServiceStatus.UNKNOWN).build()));
   }
 
   @Test
@@ -86,11 +73,9 @@ public class CmServerClusterTest extends BaseTestIntegrationServer {
     Assert.assertTrue(server.getServices(cluster).isEmpty());
     Assert.assertTrue(server.configure(cluster));
     Assert.assertFalse(server.getServices(cluster).isEmpty());
-    Assert.assertEquals(
-        new CmServerServiceBuilder().type(CmServerServiceType.HDFS_NAMENODE).tag(CLUSTER_TAG)
-            .qualifier(CmServerService.NAME_QUALIFIER_DEFAULT)
-            .host(server.getService(cluster, CmServerServiceType.HDFS_NAMENODE).getHost()),
-        server.getService(cluster, CmServerServiceType.HDFS_NAMENODE));
+    Assert.assertEquals(new CmServerServiceBuilder().type(CmServerServiceType.HDFS_NAMENODE).tag(CLUSTER_TAG)
+        .qualifier(CmServerService.NAME_QUALIFIER_DEFAULT).build().getName(),
+        server.getService(cluster, CmServerServiceType.HDFS_NAMENODE).getName());
   }
 
   @Test


### PR DESCRIPTION
Addresses:
- Implement clean-cluster command
- Remove reliance on public hostname, resolution introduces too much latency on EC2
- Improved CM connection reporting, especially during failure scenarios
- Always provision/initialise cluster even when whirr.cmauto is false
- Add optional cm-cluster-name param to command arguments to facilitate non-whirr whirr-cm interactions

Outstanding:
- Resolve start/stop/restart --roles filter issue
