### PR TITLE
Graham patch for CDH-11869

### DIFF
--- a/src/main/java/com/cloudera/whirr/cm/CmConstants.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmConstants.java
@@ -27,6 +27,8 @@ public interface CmConstants extends CmServerConstants {
   public static final String CM_USER = "admin";
   public static final String CM_PASSWORD = "admin";
 
+  public static final String CM_LICENSE_FILE = "cm-license.txt";
+  
   public static final String CONFIG_WHIRR_AUTO = "whirr.cm.auto";
   public static final String CONFIG_WHIRR_USE_PACKAGES = "whirr.cm.use.packages";
   public static final String CONFIG_WHIRR_DATA_DIRS_ROOT = "whirr.cm.data.dirs.root";
@@ -51,6 +53,9 @@ public interface CmConstants extends CmServerConstants {
   public static final String CONFIG_CM_DB_SUFFIX_HOST = "database_host";
   public static final String CONFIG_CM_DB_SUFFIX_PORT = "database_port";
   public static final String CONFIG_CM_DB_SUFFIX_NAME = "database_name";
+
+  public static final String CONFIG_CM_LICENSE_PROVIDED = "license_provided";
+  public static final String CONFIG_CM_TASKTRACKER_INSTRUMENTATION = "mapred_tasktracker_instrumentation";
 
   public static final String LOG_TAG_WHIRR_HANDLER = "Whirr Handler";
   public static final String LOG_TAG_WHIRR_COMMAND = "Whirr Command";

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -224,7 +224,9 @@ public class CmServerClusterInstance implements CmConstants {
   @SuppressWarnings("unchecked")
   public static Map<String, Map<String, String>> getClusterConfiguration(final Configuration configuration,
       SortedSet<String> mounts) throws IOException {
+
     Map<String, Map<String, String>> clusterConfiguration = new HashMap<String, Map<String, String>>();
+
     Iterator<String> keys = configuration.getKeys();
     while (keys.hasNext()) {
       String key = keys.next();
@@ -241,6 +243,7 @@ public class CmServerClusterInstance implements CmConstants {
         clusterConfiguration.get(keyTokens[0]).put(keyTokens[1], configuration.getString(key));
       }
     }
+
     keys = configuration.getKeys();
     while (keys.hasNext()) {
       final String key = keys.next();
@@ -273,6 +276,7 @@ public class CmServerClusterInstance implements CmConstants {
         }
       }
     }
+
     keys = configuration.getKeys();
     while (keys.hasNext()) {
       final String key = keys.next();
@@ -304,7 +308,31 @@ public class CmServerClusterInstance implements CmConstants {
         }
       }
     }
+
+    if (clusterConfiguration.get(CmServerServiceType.CLUSTER.getId()) == null) {
+      clusterConfiguration.put(CmServerServiceType.CLUSTER.getId(), new HashMap<String, String>());
+    }
+    if (clusterConfiguration.get(CmServerServiceType.CLUSTER.getId()).get(CONFIG_CM_LICENSE_PROVIDED) == null) {
+      if (CmServerClusterInstance.class.getClassLoader().getResource(CM_LICENSE_FILE) != null) {
+        clusterConfiguration.get(CmServerServiceType.CLUSTER.getId()).put(CONFIG_CM_LICENSE_PROVIDED,
+            Boolean.TRUE.toString());
+      } else {
+        clusterConfiguration.get(CmServerServiceType.CLUSTER.getId()).put(CONFIG_CM_LICENSE_PROVIDED,
+            Boolean.FALSE.toString());
+      }
+    }
+
+    if (clusterConfiguration.get(CmServerServiceType.CLUSTER.getId()).get(CONFIG_CM_LICENSE_PROVIDED)
+        .equals(Boolean.TRUE.toString())) {
+      if (clusterConfiguration.get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()) == null) {
+        clusterConfiguration.put(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId(), new HashMap<String, String>());
+      }
+      clusterConfiguration.get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).put(
+          CONFIG_CM_TASKTRACKER_INSTRUMENTATION, "org.apache.hadoop.mapred.TaskTrackerCmonInst");
+    }
+
     return clusterConfiguration;
+
   }
 
   public static boolean logCluster(CmServerLog logger, String label, Configuration configuration,

--- a/src/main/java/com/cloudera/whirr/cm/handler/BaseHandlerCm.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/BaseHandlerCm.java
@@ -56,7 +56,9 @@ public abstract class BaseHandlerCm extends BaseHandler {
     logHeaderHandler("HostPreConfigure");
     super.beforeConfigure(event);
     addStatement(event, call("retry_helpers"));
-    addStatement(event, call("prepare_all_disks", "'" + VolumeManager.asString(getDeviceMappings(event)) + "'"));
+    if (CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getList(CONFIG_WHIRR_DATA_DIRS_ROOT).isEmpty()) {
+      addStatement(event, call("prepare_all_disks", "'" + VolumeManager.asString(getDeviceMappings(event)) + "'"));
+    }
     logFooterHandler("HostPreConfigure");
   }
 

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
@@ -50,8 +50,6 @@ public class CmServerHandler extends BaseHandlerCm {
 
   public static final String ROLE = "cm-server";
 
-  public static final String LICENSE_FILE = "cm-license.txt";
-
   @Override
   public String getRole() {
     return ROLE;
@@ -103,11 +101,11 @@ public class CmServerHandler extends BaseHandlerCm {
   protected void beforeConfigure(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeConfigure(event);
     URL licenceConfigUri = null;
-    if ((licenceConfigUri = CmServerHandler.class.getClassLoader().getResource(LICENSE_FILE)) != null) {
+    if ((licenceConfigUri = CmServerHandler.class.getClassLoader().getResource(CM_LICENSE_FILE)) != null) {
       addStatement(
           event,
           createOrOverwriteFile(
-              "/tmp/" + LICENSE_FILE,
+              "/tmp/" + CM_LICENSE_FILE,
               Splitter.on('\n').split(
                   CharStreams.toString(Resources.newReaderSupplier(licenceConfigUri, Charsets.UTF_8)))));
     }

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -862,6 +862,8 @@ public class CmServerImpl implements CmServer {
           case HIVE:
             apiServiceConfig.add(new ApiConfig("mapreduce_yarn_service", cluster
                 .getServiceName(CmServerServiceType.MAPREDUCE)));
+            apiServiceConfig.add(new ApiConfig("zookeeper_service", cluster
+                .getServiceName(CmServerServiceType.ZOOKEEPER)));
             break;
           case IMPALA:
             apiServiceConfig.add(new ApiConfig("hdfs_service", cluster.getServiceName(CmServerServiceType.HDFS)));

--- a/src/main/resources/functions/configure_cm_cdh.sh
+++ b/src/main/resources/functions/configure_cm_cdh.sh
@@ -34,14 +34,18 @@ function configure_cm_cdh() {
   done
   export IFS=, 
   CM_CDH_DIRS_ARRAY=($CM_CDH_DIRS)
+  for i in "${CM_CDH_DIRS_ARRAY[@]}"; do
+    mkdir -p $i
+    chmod 777 $i
+  done
   if [ "$CM_CDH_ROLE" = "cm-cdh-jobtracker" ]; then
-	mkdir -p "${CM_CDH_DIRS_ARRAY[0]}/mapreduce/jobtracker/history"
-	chmod 777 "${CM_CDH_DIRS_ARRAY[0]}/mapreduce/jobtracker/history"
+  mkdir -p "${CM_CDH_DIRS_ARRAY[0]}/mapreduce/jobtracker/history"
+  chmod 777 "${CM_CDH_DIRS_ARRAY[0]}/mapreduce/jobtracker/history"
   elif [ "$CM_CDH_ROLE" = "cm-cdh-oozie-server" ]; then
-	if [ -f "/usr/share/java/mysql-connector-java.jar" ]; then
-	  mkdir -p /var/lib/oozie
-	  chmod 777 /var/lib/oozie
-	  ln -s /usr/share/java/mysql-connector-java.jar /var/lib/oozie/mysql-connector-java.jar
+  if [ -f "/usr/share/java/mysql-connector-java.jar" ]; then
+    mkdir -p /var/lib/oozie
+    chmod 777 /var/lib/oozie
+    ln -s /usr/share/java/mysql-connector-java.jar /var/lib/oozie/mysql-connector-java.jar
     fi
   fi
 }

--- a/src/main/resources/functions/install_cdh_packages.sh
+++ b/src/main/resources/functions/install_cdh_packages.sh
@@ -1,12 +1,12 @@
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
-# contributor license agreements.  See the NOTICE file distributed with
+# contributor license agreements. See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
 # The ASF licenses this file to You under the Apache License, Version 2.0
 # (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+# the License. You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#   http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,33 +17,33 @@
 set -x
 
 function install_cdh_packages() {
-    if which dpkg &> /dev/null; then
-        retry_apt_get -y install bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper hue sqoop flume-ng flume-ng-agent
-        if ls /etc/init.d/hadoop-* &> /dev/null; then
-            for SERVICE_SCRIPT in /etc/init.d/hadoop-*; do
-                service $(basename $SERVICE_SCRIPT) stop
-                update-rc.d -f $(basename $SERVICE_SCRIPT) remove
-            done
-        fi
-        service hue stop
-        update-rc.d -f hue remove
-        service flume-ng-agent stop
-        update-rc.d -f flume-ng-agent remove
-        service oozie stop
-        update-rc.d -f oozie remove
-    elif which rpm &> /dev/null; then
-        retry_yum install -y bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper impala impala-shell hue sqoop flume-ng flume-ng-agent
-        if ls /etc/init.d/hadoop-* &> /dev/null; then
-            for SERVICE_SCRIPT in /etc/init.d/hadoop-*; do
-                service $(basename $SERVICE_SCRIPT) stop
-                chkconfig $(basename $SERVICE_SCRIPT) off
-            done
-        fi
-        service hue stop
-        chkconfig hue off
-        service flume-ng-agent stop
-        chkconfig flume-ng-agent off
-        service oozie stop
-        chkconfig oozie off    
+  if which dpkg &> /dev/null; then
+    retry_apt_get -y install bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper hue sqoop flume-ng flume-ng-agent
+    if ls /etc/init.d/hadoop-* &> /dev/null; then
+      for SERVICE_SCRIPT in /etc/init.d/hadoop-*; do
+        service $(basename $SERVICE_SCRIPT) stop
+        update-rc.d -f $(basename $SERVICE_SCRIPT) remove
+      done
+    fi    
+    service hue stop
+    update-rc.d -f hue remove
+    service flume-ng-agent stop
+    update-rc.d -f flume-ng-agent remove
+    service oozie stop
+    update-rc.d -f oozie remove
+  elif which rpm &> /dev/null; then
+    retry_yum install -y bigtop-utils bigtop-jsvc bigtop-tomcat hadoop hadoop-hdfs hadoop-httpfs hadoop-mapreduce hadoop-yarn hadoop-client hadoop-0.20-mapreduce hue-plugins hbase hive oozie oozie-client pig zookeeper impala impala-shell hue sqoop flume-ng flume-ng-agent
+    if ls /etc/init.d/hadoop-* &> /dev/null; then
+      for SERVICE_SCRIPT in /etc/init.d/hadoop-*; do
+        service $(basename $SERVICE_SCRIPT) stop
+        chkconfig $(basename $SERVICE_SCRIPT) off
+      done
     fi
+    service hue stop
+    chkconfig hue off
+    service flume-ng-agent stop
+    chkconfig flume-ng-agent off
+    service oozie stop
+    chkconfig oozie off  
+  fi
 }

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -87,8 +87,6 @@ whirr.cm.config.jobtracker.mapred_job_tracker_handler_count=22
 whirr.cm.config.mapreduce_gateway.mapred_submit_replication=3
 whirr.cm.config.mapreduce_gateway.mapred_reduce_tasks=3
 
-whirr.cm.config.hiveserver2.hive_hs2_config_safety_valve=<property>\n\t<name>hive.support.concurrency</name>\n\t<value>true</value>\n</property>\n<property>\n\t<name>hive.zookeeper.quorum</name>\n\t<!-- This should be populated with the ZK instance connection strings -->\n\t<value>myzookeper-host.com</value>\n</property>
-
 whirr.cm.config.cm.cm_database_type=
 whirr.cm.config.cm.cm_database_name=cm
 

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -150,7 +150,7 @@ cm-server.port.web=7180
 cm-server.port.comms=7182
 cm-server.ports=
 
-cm-node.ports=
+cm-node.ports=4867
 
 cm-cdh-namenode.client.ports=8020,50070
 cm-cdh-secondarynamenode.client.ports=50090

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
@@ -179,6 +179,9 @@ public class CmServerHandlerTest extends BaseTestHandler {
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
             .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+    Assert.assertNull(CmServerClusterInstance
+        .getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
+        .get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
 
     configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap.of(
         "whirr.instance-templates", "1 " + CmServerHandler.ROLE + ",2 " + CmNodeHandler.ROLE,
@@ -186,7 +189,8 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + CONFIG_CM_DB_SUFFIX_NAME, "cman", CONFIG_WHIRR_CM_CONFIG_PREFIX
             + CmServerServiceTypeCms.CM.getId().toLowerCase() + "." + CONFIG_CM_DB_SUFFIX_TYPE, "postgres",
         CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceType.HIVE.getId().toLowerCase() + ".hive_metastore_"
-            + CONFIG_CM_DB_SUFFIX_PORT, "9999")));
+            + CONFIG_CM_DB_SUFFIX_PORT, "9999", CONFIG_WHIRR_CM_CONFIG_PREFIX
+            + CmServerServiceType.CLUSTER.getId().toLowerCase() + "." + CONFIG_CM_LICENSE_PROVIDED, "true")));
     Assert.assertEquals(
         "/data1"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
@@ -202,6 +206,10 @@ public class CmServerHandlerTest extends BaseTestHandler {
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/data1", "/data2"))
             .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+    Assert.assertEquals(
+        "org.apache.hadoop.mapred.TaskTrackerCmonInst",
+        CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
+            .get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
 
     configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap.of(
         "whirr.instance-templates", "1 " + CmServerHandler.ROLE + ",2 " + CmNodeHandler.ROLE,


### PR DESCRIPTION
Addresses:
- If CM license provided, ensure services have correct instrumentation settings applied
- Update Hive service wide config with zookeper service link, dropping safety valve settings, new feature of CM 4.5.2
- Do not invoke prepare_all_disks when overiden by whirr.cm.data.dirs.root, ensure data directories are created in any case
