### PR TITLE
Make CM license file configurable

### DIFF
--- a/src/main/java/com/cloudera/whirr/cm/CmConstants.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmConstants.java
@@ -35,6 +35,7 @@ public interface CmConstants extends CmServerConstants {
   public static final String CONFIG_WHIRR_FIREWALL_ENABLE = "whirr.cm.firewall.enable";
   public static final String CONFIG_WHIRR_DB_TYPE = "whirr.cm.db.type";
   public static final String CONFIG_WHIRR_CM_CONFIG_PREFIX = "whirr.cm.config.";
+  public static final String CONFIG_WHIRR_CM_LICENSE_URI = "whirr.cm.license.uri";
 
   public static final String CONFIG_WHIRR_INTERNAL_AGENT_LOG_FILE = "whirr.cm.agent.log.file";
   public static final String CONFIG_WHIRR_INTERNAL_DATA_DIRS_DEFAULT = "whirr.cm.data.dirs.root.default";

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -38,6 +38,7 @@ import org.apache.whirr.Cluster.Instance;
 import org.apache.whirr.ClusterSpec;
 import org.apache.whirr.service.ClusterActionEvent;
 
+import com.cloudera.whirr.cm.Utils;
 import com.cloudera.whirr.cm.handler.CmAgentHandler;
 import com.cloudera.whirr.cm.handler.CmNodeHandler;
 import com.cloudera.whirr.cm.handler.CmServerHandler;
@@ -338,7 +339,7 @@ public class CmServerClusterInstance implements CmConstants {
       clusterConfiguration.put(CmServerServiceType.CLUSTER.getId(), new HashMap<String, String>());
     }
     if (clusterConfiguration.get(CmServerServiceType.CLUSTER.getId()).get(CONFIG_CM_LICENSE_PROVIDED) == null) {
-      if (CmServerClusterInstance.class.getClassLoader().getResource(CM_LICENSE_FILE) != null) {
+      if (Utils.urlForURI(configuration.getString(CONFIG_WHIRR_CM_LICENSE_URI)) != null) {
         clusterConfiguration.get(CmServerServiceType.CLUSTER.getId()).put(CONFIG_CM_LICENSE_PROVIDED,
             Boolean.TRUE.toString());
       } else {

--- a/src/main/java/com/cloudera/whirr/cm/Utils.java
+++ b/src/main/java/com/cloudera/whirr/cm/Utils.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.whirr.cm;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Resources;
+
+public class Utils {
+
+    public static URL urlForURI(String inputStr) {
+        try {
+            if (inputStr == null) {
+                return null;
+            }
+            URI input = new URI(inputStr).normalize();
+            if (input.getScheme() != null && input.getScheme().equals("classpath")) {
+                return Utils.class.getResource(input.getPath());
+            }
+            if (Resources.toString(input.toURL(), Charsets.UTF_8) != null) {
+                return input.toURL();
+            } else {
+                return null;
+            }
+      } catch (IOException e) {
+            // Swallow the exception for now and just return null - this could probably be better.
+            return null;
+      } catch (URISyntaxException e) {
+            // Swallow the exception for now and just return null - this could probably be better.
+            return null;
+      }
+   }
+}
+
+    

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmServerHandler.java
@@ -32,6 +32,7 @@ import org.apache.whirr.service.ClusterActionEvent;
 
 import com.cloudera.whirr.cm.CmConstants;
 import com.cloudera.whirr.cm.CmServerClusterInstance;
+import com.cloudera.whirr.cm.Utils;
 import com.cloudera.whirr.cm.server.CmServer;
 import com.cloudera.whirr.cm.server.CmServerCluster;
 import com.cloudera.whirr.cm.server.CmServerException;
@@ -113,7 +114,7 @@ public class CmServerHandler extends BaseHandlerCm {
     CmServerClusterInstance.logLineItemAsync(logger, "HostConfigureInit");
     super.beforeConfigure(event);
     URL licenceConfigUri = null;
-    if ((licenceConfigUri = CmServerHandler.class.getClassLoader().getResource(CM_LICENSE_FILE)) != null) {
+    if ((licenceConfigUri = Utils.urlForURI(CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getString(CONFIG_WHIRR_CM_LICENSE_URI))) != null) {
       addStatement(
           event,
           createOrOverwriteFile(

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -22,6 +22,7 @@ whirr.cm.use.packages=false
 whirr.cm.data.dirs.root.default=/data
 whirr.cm.firewall.enable=false
 whirr.cm.db.type=mysql
+whirr.cm.license.uri=classpath:///cm-license.txt
 
 whirr.cm.agent.log.file=/manager/agent/log/agent.log
 

--- a/src/test/java/com/cloudera/whirr/cm/UtilsTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/UtilsTest.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.whirr.cm;
+
+import java.io.File;
+import java.net.URL;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UtilsTest implements BaseTest {
+    
+    @Test
+    public void testUrlForURI() throws Exception {
+        Assert.assertNull(Utils.urlForURI("classpath:///file-that-does-not-exist-we-hope"));
+                                
+        Assert.assertNull(Utils.urlForURI("http://www.exmaple.com/non-existant-url"));
+
+        Assert.assertEquals(Utils.urlForURI("classpath:///whirr-cm-default.properties"),
+                            UtilsTest.class.getClassLoader().getResource("whirr-cm-default.properties"));
+
+        File pom = new File("pom.xml");
+        Assert.assertEquals(Utils.urlForURI("file://" + pom.getAbsolutePath()),
+                            pom.toURI().toURL());
+        
+    }    
+}

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
@@ -217,6 +217,36 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + CONFIG_CM_DB_SUFFIX_NAME, "cman", CONFIG_WHIRR_CM_CONFIG_PREFIX
             + CmServerServiceTypeCms.CM.getId().toLowerCase() + "." + CONFIG_CM_DB_SUFFIX_TYPE, "postgres",
         CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceType.HIVE.getId().toLowerCase() + ".hive_metastore_"
+        + CONFIG_CM_DB_SUFFIX_PORT, "9999", CONFIG_WHIRR_CM_LICENSE_URI, "classpath:///whirr-cm-default.properties")));
+    Assert.assertEquals(
+        "/data1"
+            + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
+                + CmServerServiceTypeCms.NAVIGATOR.getId().toLowerCase() + ".mgmt_log_dir"),
+        CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/data1", "/data2"))
+            .get(CmServerServiceTypeCms.NAVIGATOR.getId()).get("mgmt_log_dir"));
+    Assert.assertEquals(
+        "/data1"
+            + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
+                + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list")
+            + ",/data2"
+            + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
+                + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
+        CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/data1", "/data2"))
+            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+    Assert.assertEquals(
+        "org.apache.hadoop.mapred.TaskTrackerCmonInst",
+        CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
+            .get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
+    Assert.assertEquals("classpath:///whirr-cm-default.properties",
+                        configuration.getString(CONFIG_WHIRR_CM_LICENSE_URI));
+                        
+    
+    configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap.of(
+        "whirr.instance-templates", "1 " + CmServerHandler.ROLE + ",2 " + CmNodeHandler.ROLE,
+        CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceTypeCms.CM.getId().toLowerCase() + "."
+            + CONFIG_CM_DB_SUFFIX_NAME, "cman", CONFIG_WHIRR_CM_CONFIG_PREFIX
+            + CmServerServiceTypeCms.CM.getId().toLowerCase() + "." + CONFIG_CM_DB_SUFFIX_TYPE, "postgres",
+        CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceType.HIVE.getId().toLowerCase() + ".hive_metastore_"
             + CONFIG_CM_DB_SUFFIX_PORT, "9999")));
     Assert.assertEquals(
         "/tmp"


### PR DESCRIPTION
Any URI - can be classpath:///cm-license.txt (i.e., the default), any other classpath URI, file://, http://, etc.
