### PR TITLE
CDH-12449 Improve whirr-cm integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,35 @@ that all data and state stored on the cluster will be lost.
 ```bash
 whirr destroy-cluster --config cm-ec2.properties
 ```
+
+## Unit and Integration Tests
+
+This project includes a full suit of unit tests, launchable via:
+
+```bash
+mvn test -Dmaven.assembly.skip=true
+```
+
+The smoke integration test can be launched against Amazon EC2 via:
+
+```bash
+mvn integration-test -Pintegration -Dtest=CmServerSmokeTest#testCleanClusterLifecycle -Dwhirr.test.identity=$AWS_ACCESS_KEY -Dwhirr.test.credential=$AWS_SECRET_KEY
+```
+
+The full set of integration tests can be laucnhed against Amazon EC2 via:
+
+```bash
+mvn integration-test -Pintegration -Dmaven.test.skip=true -Dmaven.assembly.skip=true -Dwhirr.test.identity=$AWS_ACCESS_KEY -Dwhirr.test.credential=$AWS_SECRET_KEY
+```
+
+The integration tests setup and teardown a cluster automatically, if you would like to launch and persist a cluster between integration tests for iterative testing minus the cluster bootstrap costs, a cluster can be launched via:
+
+```bash
+mvn exec:java -Dexec.mainClass="com.cloudera.whirr.cm.BaseTestIntegrationBoostrap" -Dexec.classpathScope="test" -Dwhirr.test.identity=$AWS_ACCESS_KEY -Dwhirr.test.credential=$AWS_SECRET_KEY -Dlog4j.configuration=file:./target/test-classes/log4j.properties
+```
+
+and then destroyed via:
+
+```bash
+mvn exec:java -Dexec.mainClass="com.cloudera.whirr.cm.BaseTestIntegrationDestroy" -Dexec.classpathScope="test" -Dwhirr.test.identity=$AWS_ACCESS_KEY -Dwhirr.test.credential=$AWS_SECRET_KEY -Dlog4j.configuration=file:./target/test-classes/log4j.properties
+```

--- a/src/main/java/com/cloudera/whirr/cm/CmConstants.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmConstants.java
@@ -24,11 +24,12 @@ public interface CmConstants extends CmServerConstants {
 
   public static final String PROPERTIES_FILE = "whirr-cm-default.properties";
 
+  public static final int CM_PORT = 7180;
   public static final String CM_USER = "admin";
   public static final String CM_PASSWORD = "admin";
 
   public static final String CM_LICENSE_FILE = "cm-license.txt";
-  
+
   public static final String CONFIG_WHIRR_AUTO = "whirr.cm.auto";
   public static final String CONFIG_WHIRR_USE_PACKAGES = "whirr.cm.use.packages";
   public static final String CONFIG_WHIRR_DATA_DIRS_ROOT = "whirr.cm.data.dirs.root";

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -75,14 +75,14 @@ public class CmServerClusterInstance implements CmConstants {
   }
 
   private static final LoadingCache<Key, CmServerCluster> clusterCache = CacheBuilder.newBuilder().build(
-        new CacheLoader<Key, CmServerCluster>(){
-               
+      new CacheLoader<Key, CmServerCluster>() {
+
         @Override
         public CmServerCluster load(Key arg0) {
           return new CmServerCluster();
         }
-        });
-  
+      });
+
   public static synchronized void clear() {
     clusterCache.invalidateAll();
     ports.clear();
@@ -153,18 +153,18 @@ public class CmServerClusterInstance implements CmConstants {
     }
   }
 
-  public static synchronized CmServerCluster getCluster(ClusterSpec spec, Configuration configuration, Set<Instance> instances)
-      throws CmServerException, IOException {
+  public static synchronized CmServerCluster getCluster(ClusterSpec spec, Configuration configuration,
+      Set<Instance> instances) throws CmServerException, IOException {
     return getCluster(spec, configuration, instances, new TreeSet<String>(), Collections.<String> emptySet());
   }
 
-  public static synchronized CmServerCluster getCluster(ClusterSpec spec, Configuration configuration, Set<Instance> instances,
-      SortedSet<String> mounts) throws CmServerException, IOException {
+  public static synchronized CmServerCluster getCluster(ClusterSpec spec, Configuration configuration,
+      Set<Instance> instances, SortedSet<String> mounts) throws CmServerException, IOException {
     return getCluster(spec, configuration, instances, mounts, Collections.<String> emptySet());
   }
 
-  public static synchronized CmServerCluster getCluster(ClusterSpec spec, Configuration configuration, Set<Instance> instances,
-      SortedSet<String> mounts, Set<String> roles) throws CmServerException, IOException {
+  public static synchronized CmServerCluster getCluster(ClusterSpec spec, Configuration configuration,
+      Set<Instance> instances, SortedSet<String> mounts, Set<String> roles) throws CmServerException, IOException {
     CmServerCluster cluster = new CmServerCluster();
     clusterCache.put(new Key(spec), cluster);
     cluster.setIsParcel(!configuration.getBoolean(CONFIG_WHIRR_USE_PACKAGES, false));
@@ -499,7 +499,7 @@ public class CmServerClusterInstance implements CmConstants {
     private String version;
 
     private final String key;
-    
+
     public Key(ClusterSpec spec) {
       provider = spec.getProvider();
       endpoint = spec.getEndpoint();
@@ -507,19 +507,14 @@ public class CmServerClusterInstance implements CmConstants {
       clusterName = spec.getClusterName();
       version = spec.getVersion();
 
-      key = Objects.toStringHelper("").omitNullValues()
-        .add("provider", provider)
-        .add("endpoint", endpoint)
-        .add("identity", identity)
-        .add("clusterName", clusterName)
-        .add("version", version).toString();
+      key = Objects.toStringHelper("").omitNullValues().add("provider", provider).add("endpoint", endpoint)
+          .add("identity", identity).add("clusterName", clusterName).add("version", version).toString();
     }
 
- 
     @Override
     public boolean equals(Object that) {
       if (that instanceof Key) {
-        return Objects.equal(this.key, ((Key)that).key);
+        return Objects.equal(this.key, ((Key) that).key);
       }
       return false;
     }
@@ -528,17 +523,12 @@ public class CmServerClusterInstance implements CmConstants {
     public int hashCode() {
       return Objects.hashCode(key);
     }
-    
+
     @Override
     public String toString() {
-      return Objects.toStringHelper(this)
-        .add("provider", provider)
-        .add("endpoint", identity)
-        .add("identity", identity)
-        .add("clusterName", clusterName)
-        .add("version", version)
-        .toString();
+      return Objects.toStringHelper(this).add("provider", provider).add("endpoint", identity).add("identity", identity)
+          .add("clusterName", clusterName).add("version", version).toString();
     }
   }
-  
+
 }

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegration.java
@@ -79,7 +79,7 @@ public abstract class BaseTestIntegration implements BaseTest {
   }
 
   public static boolean clusterInitialised() {
-    return new File(new File(System.getProperty("user.home")), ".whirr/whirr/instances").exists();
+    return new File(new File(System.getProperty("user.home")), ".whirr/whirrcmtest/instances").exists();
   }
 
   public static Configuration clusterConfig() throws ConfigurationException {

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegrationBoostrap.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegrationBoostrap.java
@@ -17,20 +17,17 @@
  */
 package com.cloudera.whirr.cm;
 
-import java.io.File;
+public class BaseTestIntegrationBoostrap {
 
-import org.junit.Assert;
-import org.junit.Test;
-
-public class UtilsTest implements BaseTest {
-
-  @Test
-  public void testUrlForURI() throws Exception {
-    Assert.assertNull(Utils.urlForURI("classpath:///file-that-does-not-exist-we-hope"));
-    Assert.assertNull(Utils.urlForURI("http://www.exmaple.com/non-existant-url"));
-    Assert.assertEquals(Utils.urlForURI("classpath:///whirr-cm-default.properties"), UtilsTest.class.getClassLoader()
-        .getResource("whirr-cm-default.properties"));
-    File pom = new File("pom.xml");
-    Assert.assertEquals(Utils.urlForURI("file://" + pom.getAbsolutePath()), pom.toURI().toURL());
+  public static void main(String[] args) {
+    int returnValue = 0;
+    try {
+      BaseTestIntegration.clusterBootstrap();
+    } catch (Exception e) {
+      e.printStackTrace();
+      returnValue = 1;
+    }
+    System.exit(returnValue);
   }
+
 }

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegrationDestroy.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegrationDestroy.java
@@ -17,20 +17,17 @@
  */
 package com.cloudera.whirr.cm;
 
-import java.io.File;
+public class BaseTestIntegrationDestroy {
 
-import org.junit.Assert;
-import org.junit.Test;
-
-public class UtilsTest implements BaseTest {
-
-  @Test
-  public void testUrlForURI() throws Exception {
-    Assert.assertNull(Utils.urlForURI("classpath:///file-that-does-not-exist-we-hope"));
-    Assert.assertNull(Utils.urlForURI("http://www.exmaple.com/non-existant-url"));
-    Assert.assertEquals(Utils.urlForURI("classpath:///whirr-cm-default.properties"), UtilsTest.class.getClassLoader()
-        .getResource("whirr-cm-default.properties"));
-    File pom = new File("pom.xml");
-    Assert.assertEquals(Utils.urlForURI("file://" + pom.getAbsolutePath()), pom.toURI().toURL());
+  public static void main(String[] args) {
+    int returnValue = 0;
+    try {
+      BaseTestIntegration.clusterDestroy();
+    } catch (Exception e) {
+      e.printStackTrace();
+      returnValue = 1;
+    }
+    System.exit(returnValue);
   }
+
 }

--- a/src/test/java/com/cloudera/whirr/cm/BaseTestIntegrationStatus.java
+++ b/src/test/java/com/cloudera/whirr/cm/BaseTestIntegrationStatus.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.whirr.cm;
+
+public class BaseTestIntegrationStatus {
+
+  public static void main(String[] args) {
+    int returnValue = 0;
+    try {
+      if (BaseTestIntegration.clusterInitialised()) {
+        System.out.println("\n\nIntegration cluster available, CM Server at: http://"
+            + BaseTestIntegration.clusterTopology().getServer().getIp() + ":" + CmConstants.CM_PORT + "\n\n");
+      } else {
+        System.out.println("\n\nIntegration cluster not available\n\n");
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+      returnValue = 1;
+    }
+    System.exit(returnValue);
+  }
+
+}

--- a/src/test/java/com/cloudera/whirr/cm/cmd/integration/BaseTestIntegrationCommand.java
+++ b/src/test/java/com/cloudera/whirr/cm/cmd/integration/BaseTestIntegrationCommand.java
@@ -34,7 +34,7 @@ public abstract class BaseTestIntegrationCommand extends BaseTestIntegration {
   @Before
   public void provisionCluster() throws Exception {
     super.provisionCluster();
-    command = new CmServerBuilder().ip(CM_IP).cluster(cluster).path(DIR_CLIENT_CONFIG.getAbsolutePath());
+    command = new CmServerBuilder().ip(cluster.getServer().getIp()).cluster(cluster).path(DIR_CLIENT_CONFIG.getAbsolutePath());
     Configuration configuration = new PropertiesConfiguration();
     configuration.setProperty(ClusterSpec.Property.CLUSTER_USER.getConfigName(), CLUSTER_USER);
     configuration.setProperty(ClusterSpec.Property.PRIVATE_KEY_FILE.getConfigName(), FILE_KEY_PRIVATE.getAbsolutePath());

--- a/src/test/java/com/cloudera/whirr/cm/integration/CmServerSmokeTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/integration/CmServerSmokeTest.java
@@ -1,0 +1,59 @@
+package com.cloudera.whirr.cm.integration;
+
+import java.io.IOException;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.cloudera.whirr.cm.BaseTestIntegration;
+import com.cloudera.whirr.cm.CmConstants;
+import com.cloudera.whirr.cm.server.CmServer;
+import com.cloudera.whirr.cm.server.CmServerException;
+import com.cloudera.whirr.cm.server.impl.CmServerFactory;
+import com.cloudera.whirr.cm.server.impl.CmServerLog;
+
+public class CmServerSmokeTest extends BaseTestIntegration {
+
+  protected static CmServer server;
+
+  @BeforeClass
+  public static void initialiseServer() throws CmServerException {
+    Assert.assertNotNull(server = new CmServerFactory().getCmServer(cluster.getServer().getIp(), CM_PORT,
+        CmConstants.CM_USER, CmConstants.CM_PASSWORD, new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API, false)));
+  }
+
+  @Test
+  public void testCleanClusterLifecycle() throws ConfigurationException, IOException, InterruptedException,
+      CmServerException {
+
+    Assert.assertTrue(server.isProvisioned(cluster));
+    Assert.assertFalse(server.isConfigured(cluster));
+    Assert.assertFalse(server.isStarted(cluster));
+    Assert.assertTrue(server.isStopped(cluster));
+
+    Assert.assertTrue(server.configure(cluster));
+
+    Assert.assertTrue(server.isProvisioned(cluster));
+    Assert.assertTrue(server.isConfigured(cluster));
+    Assert.assertFalse(server.isStarted(cluster));
+    Assert.assertTrue(server.isStopped(cluster));
+
+    Assert.assertTrue(server.start(cluster));
+
+    Assert.assertTrue(server.isProvisioned(cluster));
+    Assert.assertTrue(server.isConfigured(cluster));
+    Assert.assertTrue(server.isStarted(cluster));
+    Assert.assertFalse(server.isStopped(cluster));
+
+    Assert.assertTrue(server.stop(cluster));
+
+    Assert.assertTrue(server.isProvisioned(cluster));
+    Assert.assertTrue(server.isConfigured(cluster));
+    Assert.assertFalse(server.isStarted(cluster));
+    Assert.assertTrue(server.isStopped(cluster));
+
+  }
+
+}

--- a/src/test/java/com/cloudera/whirr/cm/server/integration/BaseTestIntegrationServer.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/integration/BaseTestIntegrationServer.java
@@ -33,7 +33,7 @@ public class BaseTestIntegrationServer extends BaseTestIntegration {
 
   @BeforeClass
   public static void initialiseServer() throws CmServerException {
-    Assert.assertNotNull(server = new CmServerFactory().getCmServer(CM_IP, CM_PORT, CmConstants.CM_USER,
+    Assert.assertNotNull(server = new CmServerFactory().getCmServer(cluster.getServer().getIp(), CM_PORT, CmConstants.CM_USER,
         CmConstants.CM_PASSWORD, new CmServerLog.CmServerLogSysOut(LOG_TAG_CM_SERVER_API, false)));
   }
 

--- a/src/test/java/com/cloudera/whirr/cm/server/integration/CmServerClusterTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/integration/CmServerClusterTest.java
@@ -38,7 +38,7 @@ public class CmServerClusterTest extends BaseTestIntegrationServer {
   @Test
   public void testGetServiceHost() throws CmServerException {
     List<CmServerService> serviceHosts = server.getServiceHosts();
-    Assert.assertEquals(clusterSize, serviceHosts.size());
+    Assert.assertEquals(5, serviceHosts.size());
     Assert.assertTrue(serviceHosts.size() > 2);
     Assert.assertEquals(serviceHosts.get(2).getHost(),
         server.getServiceHost(new CmServerServiceBuilder().host(serviceHosts.get(2).getHost()).build()).getHost());

--- a/src/test/resources/cm.properties
+++ b/src/test/resources/cm.properties
@@ -1,0 +1,40 @@
+#
+# Licensed to Cloudera, Inc. under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# Cloudera, Inc. licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+whirr.instance-templates=1 cm-server+cm-agent,1 cm-agent+cm-cdh-namenode+cm-cdh-secondarynamenode+cm-cdh-oozie-server+cm-cdh-hbase-master+cm-cdh-jobtracker+cm-cdh-hivemetastore+cm-cdh-impala-statestore+cm-cdh-hue-server+cm-cdh-hue-beeswaxserver,3 cm-agent+cm-cdh-datanode+cm-cdh-tasktracker+cm-cdh-hbase-regionserver+cm-cdh-impala-daemon+cm-cdh-zookeeper
+
+whirr.cluster-name=whirr
+whirr.cluster-user=whirr
+whirr.client-cidrs=0.0.0.0/0
+
+whirr.private-key-file=./src/test/resources/test-key
+whirr.public-key-file=./src/test/resources/test-key.pub
+
+whirr.credential=${sys:whirr.test.credential}
+whirr.identity=${sys:whirr.test.identity}
+
+whirr.provider=aws-ec2
+whirr.hardware-id=m1.medium
+whirr.image-id=us-east-1/ami-d0f89fb9
+whirr.location-id=us-east-1
+
+whirr.cm.auto=false
+whirr.cm.firewall.enable=true
+
+jclouds.compute.timeout.port-open=1200000
+jclouds.compute.timeout.node-running=3200000
+jclouds.compute.timeout.script-complete=18000000

--- a/src/test/resources/cm.properties
+++ b/src/test/resources/cm.properties
@@ -17,7 +17,7 @@
 
 whirr.instance-templates=1 cm-server+cm-agent,1 cm-agent+cm-cdh-namenode+cm-cdh-secondarynamenode+cm-cdh-oozie-server+cm-cdh-hbase-master+cm-cdh-jobtracker+cm-cdh-hivemetastore+cm-cdh-impala-statestore+cm-cdh-hue-server+cm-cdh-hue-beeswaxserver,3 cm-agent+cm-cdh-datanode+cm-cdh-tasktracker+cm-cdh-hbase-regionserver+cm-cdh-impala-daemon+cm-cdh-zookeeper
 
-whirr.cluster-name=whirr
+whirr.cluster-name=whirrcmtest
 whirr.cluster-user=whirr
 whirr.client-cidrs=0.0.0.0/0
 

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -20,7 +20,4 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.conversionPattern=%d %-5p %m%n
 #log4j.appender.stdout.layout.conversionPattern=%d %p [%t] %c %l %m%n
 
-log4j.logger.org.apache=FATAL
-log4j.logger.com.cloudera.whirr.cm=INFO
-
-log4j.rootLogger=WARN,stdout
+log4j.rootLogger=FATAL,stdout


### PR DESCRIPTION
Implemented:
- If necessary, automatically boostrap/destroy cluster for integration tests
- Provide ability to boostrap/destroy cluster for iterative integration tests
- Implement a smoke test for quick integration litmus test
- Update doc to describe how to integration test
