### PR TITLE
CDH-14400: Update Whirr-CM for CM 4.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ export PATH=$WHIRR_HOME/bin:$PATH
 ### Create a password-less SSH keypair for Whirr to use:
 
 ```bash
-ssh-keygen -t rsa -P '' -f ~/.ssh/id_rsa_cm
+ssh-keygen -t rsa -P '' -f ~/.ssh/whirr
 ```
 
 ## Install the Whirr Cloudera Manager Plugin (optional)
@@ -213,6 +213,22 @@ that all data and state stored on the cluster will be lost.
 
 ```bash
 whirr destroy-cluster --config cm-ec2.properties
+```
+
+## Troubleshooting a failed Cluster launch
+
+During launch, errors will be printed to the console indicating root cause, halting operation and cleaning up any cluster resources that were provisioned. In some rare cases, Whirr can block for an extended time without an error message (eg node disk space exhaustion, network partition etc) in which case you can investigate the issue by looking at the client side whirr.log in the current dir, cloud web console, the nodes via SSH or Cloudera Manager depending upon which stage Whirr has got to. 
+
+If the host bootstrap has failed, you should investigate the image you are using, manually creating an instance from it and attempting connection via the whirr.bootstrap-user (ec2-user) by SSH and troubleshooting.  If this is successful, you should attempt to connect to the nodes provisioned by Whirr, by using the hosts specified in the cloud web console, the whirr.cluster-user (whirr) and the whirr.private-key-file (~/.ssh/whirr). If the connections succeed, it is likely Whirr is still running or blocking and the scripts and logs Whirr stages to /tmp on each node should help to determine the root cause:
+
+```bash
+ssh -o StrictHostKeyChecking=no -i ~/.ssh/whirr whirr@ec2-54-212-158-37.us-west-2.compute.amazonaws.com "ls -la /tmp/bootstrap* /tmp/configure*"
+```
+
+If you destroy the instances Whirr has created outside of Whirr (ie through the cloud web console) you will have to clean up the Whirr instance store before re-running:
+
+```bash
+rm -rf ~/.whirr/mycluster
 ```
 
 ## Unit and Integration Tests

--- a/cm-ec2.properties
+++ b/cm-ec2.properties
@@ -27,7 +27,7 @@ whirr.instance-templates=\
 1 cm-cdh-namenode+cm-cdh-hue-server+cm-cdh-hue-beeswaxserver+cm-cdh-httpfs+cm-cdh-zookeeper+cm-agent,\
 1 cm-cdh-secondarynamenode+cm-cdh-oozie-server+cm-cdh-hbase-master+cm-cdh-sqoop-server+cm-cdh-zookeeper+cm-cdh-httpfs+cm-agent,\
 1 cm-cdh-jobtracker+cm-cdh-hivemetastore+cm-cdh-impala-statestore+cm-cdh-hiveserver2+cm-cdh-hcatalog+cm-cdh-zookeeper+cm-cdh-httpfs+cm-agent,\
-3 cm-cdh-datanode+cm-cdh-tasktracker+cm-cdh-hbase-regionserver+cm-cdh-impala-daemon+cm-cdh-solr-server+cm-cdh-flume-agent+cm-cdh-httpfs+cm-agent
+3 cm-cdh-datanode+cm-cdh-tasktracker+cm-cdh-hbase-regionserver+cm-cdh-impala-daemon+cm-cdh-solr-server+cm-cdh-solr-hbase-indexer+cm-cdh-flume-agent+cm-cdh-httpfs+cm-agent
 
 # List of client IP ranges that can access the CM and CDH web console and client servers
 # Note that CM is deployed with the default admin accounts and credentials and CDH is provisioned

--- a/cm-ec2.properties
+++ b/cm-ec2.properties
@@ -66,7 +66,7 @@ whirr.location-id=us-west-2c
 
 # Define the CM repository version in 'cm$MAJOR_VERSION.$MINOR_VERSION.$INCREMENTAL_VERSION'
 # format (major version mandatory, minor and incremental optional), defaults to latest available
-whirr.env.repocm=cm4.6.3
+whirr.env.repocm=cm4.7.0
 
 # Define the CM API version in 'v$MAJOR_VERSION' format, defaults to most advanced available from CM version
 #whirr.cm.api=v4

--- a/cm-ec2.properties
+++ b/cm-ec2.properties
@@ -46,7 +46,7 @@ whirr.identity=${env:WHIRR_CLOUD_PROVIDER_ID}
 whirr.credential=${env:WHIRR_CLOUD_PROVIDER_KEY}
 whirr.hardware-id=m1.large
 whirr.image-id=us-west-2/ami-fb68f8cb
-whirr.location-id=us-west-2
+whirr.location-id=us-west-2c
 
 # Switch to enable (true) or disable (false) the automatic setup of a cluster within CM,
 # its initialization and launch, defaults to true

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<skipASs>true</skipASs>
 
 		<whirr.version>0.8.2-cdh4.3.1</whirr.version>
-		<cm.version>4.6.0</cm.version>
+		<cm.version>4.7.0</cm.version>
 		<log4j.version>1.2.16</log4j.version>
 		<slf4j.version>1.6.4</slf4j.version>
 		<hamcrest-all.version>1.1</hamcrest-all.version>

--- a/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
+++ b/src/main/java/com/cloudera/whirr/cm/CmServerClusterInstance.java
@@ -34,6 +34,7 @@ import org.apache.commons.configuration.CompositeConfiguration;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang.StringUtils;
 import org.apache.whirr.Cluster;
 import org.apache.whirr.Cluster.Instance;
 import org.apache.whirr.ClusterSpec;
@@ -281,6 +282,10 @@ public class CmServerClusterInstance implements CmConstants {
       keyTokensValidated[1] = keyTokens[0].toUpperCase();
       keyTokensValidated[2] = keyTokens[1];
     } else {
+      if (!StringUtils.isNumeric(keyTokens[0])) {
+        throw new IOException("Invalid key [" + key + "], expected to be of format [" + prefix
+            + "<version>.<role>.<setting>]");
+      }
       keyTokensValidated[0] = keyTokens[0];
       keyTokensValidated[1] = keyTokens[1].toUpperCase();
       keyTokensValidated[2] = keyTokens[2];

--- a/src/main/java/com/cloudera/whirr/cm/Utils.java
+++ b/src/main/java/com/cloudera/whirr/cm/Utils.java
@@ -27,28 +27,26 @@ import com.google.common.io.Resources;
 
 public class Utils {
 
-    public static URL urlForURI(String inputStr) {
-        try {
-            if (inputStr == null) {
-                return null;
-            }
-            URI input = new URI(inputStr).normalize();
-            if (input.getScheme() != null && input.getScheme().equals("classpath")) {
-                return Utils.class.getResource(input.getPath());
-            }
-            if (Resources.toString(input.toURL(), Charsets.UTF_8) != null) {
-                return input.toURL();
-            } else {
-                return null;
-            }
-      } catch (IOException e) {
-            // Swallow the exception for now and just return null - this could probably be better.
-            return null;
-      } catch (URISyntaxException e) {
-            // Swallow the exception for now and just return null - this could probably be better.
-            return null;
+  public static URL urlForURI(String inputStr) {
+    try {
+      if (inputStr == null) {
+        return null;
       }
-   }
+      URI input = new URI(inputStr).normalize();
+      if (input.getScheme() != null && input.getScheme().equals("classpath")) {
+        return Utils.class.getResource(input.getPath());
+      }
+      if (Resources.toString(input.toURL(), Charsets.UTF_8) != null) {
+        return input.toURL();
+      } else {
+        return null;
+      }
+    } catch (IOException e) {
+      // Swallow the exception for now and just return null - this could probably be better.
+      return null;
+    } catch (URISyntaxException e) {
+      // Swallow the exception for now and just return null - this could probably be better.
+      return null;
+    }
+  }
 }
-
-    

--- a/src/main/java/com/cloudera/whirr/cm/cmd/CmServerDestroyServicesCommand.java
+++ b/src/main/java/com/cloudera/whirr/cm/cmd/CmServerDestroyServicesCommand.java
@@ -49,7 +49,7 @@ public class CmServerDestroyServicesCommand extends BaseCommandCmServer {
   public boolean isRoleFilterable() {
     return true;
   }
-  
+
   @Override
   public int run(ClusterSpec specification, Set<Instance> instances, CmServerCluster cluster,
       CmServerBuilder serverCommand) throws Exception {

--- a/src/main/java/com/cloudera/whirr/cm/handler/BaseHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/BaseHandler.java
@@ -66,8 +66,8 @@ public abstract class BaseHandler extends ClusterActionHandlerSupport implements
           call(
               "prepare_all_disks",
               "'"
-                  + VolumeManager.asString(CmServerClusterInstance.getDeviceMappings(event.getClusterSpec(), event.getCluster()))
-                  + "'"));
+                  + VolumeManager.asString(CmServerClusterInstance.getDeviceMappings(event.getClusterSpec(),
+                      event.getCluster())) + "'"));
     }
     if (CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getBoolean(CONFIG_WHIRR_FIREWALL_ENABLE, true)) {
       Set<Integer> ports = CmServerClusterInstance.portsPush(event, getPortsClient(event));

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmAgentHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmAgentHandler.java
@@ -66,7 +66,8 @@ public class CmAgentHandler extends CmNodeHandler {
     } catch (Exception exception) {
     }
     if (cmServerInstance != null) {
-      String firstMount = CmServerClusterInstance.getMounts(event.getClusterSpec(), event.getCluster()).iterator().next();
+      String firstMount = CmServerClusterInstance.getMounts(event.getClusterSpec(), event.getCluster()).iterator()
+          .next();
       addStatement(
           event,
           call(

--- a/src/main/java/com/cloudera/whirr/cm/handler/CmNodeHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/CmNodeHandler.java
@@ -55,7 +55,8 @@ public class CmNodeHandler extends BaseHandlerCm {
   protected void beforeBootstrap(ClusterActionEvent event) throws IOException, InterruptedException {
     super.beforeBootstrap(event);
     try {
-      CmServerClusterInstance.getCluster(event.getClusterSpec()).addNode(new CmServerServiceBuilder().host(getInstanceId(event.getClusterSpec())).build());
+      CmServerClusterInstance.getCluster(event.getClusterSpec()).addNode(
+          new CmServerServiceBuilder().host(getInstanceId(event.getClusterSpec())).build());
     } catch (CmServerException e) {
       throw new IOException("Unexpected error building cluster", e);
     }

--- a/src/main/java/com/cloudera/whirr/cm/handler/cdh/BaseHandlerCmCdh.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/cdh/BaseHandlerCmCdh.java
@@ -78,8 +78,9 @@ public abstract class BaseHandlerCmCdh extends BaseHandler {
           call("install_database", "-t", CmServerClusterInstance.getClusterConfiguration(event.getClusterSpec(),
               CmServerClusterInstance.getMounts(event.getClusterSpec(), event.getCluster()), getType().getId(),
               getType().getParent() == null ? null : getType().getParent().getId(), CONFIG_CM_DB_SUFFIX_TYPE), "-d",
-              CmServerClusterInstance.getClusterConfiguration(event.getClusterSpec(), CmServerClusterInstance.getMounts(event.getClusterSpec(), event.getCluster()), getType()
-                  .getId(), getType().getParent() == null ? null : getType().getParent().getId(), "database_name")));
+              CmServerClusterInstance.getClusterConfiguration(event.getClusterSpec(),
+                  CmServerClusterInstance.getMounts(event.getClusterSpec(), event.getCluster()), getType().getId(),
+                  getType().getParent() == null ? null : getType().getParent().getId(), "database_name")));
     }
     if (CmServerClusterInstance.getConfiguration(event.getClusterSpec()).getBoolean(CONFIG_WHIRR_USE_PACKAGES, false)) {
       addStatement(event, call("register_cdh_repo"));
@@ -108,13 +109,20 @@ public abstract class BaseHandlerCmCdh extends BaseHandler {
     super.beforeConfigure(event);
     addStatement(
         event,
-        call("configure_cm_cdh", "-r", getRole(), "-d",
-            Joiner.on(',').join(Lists.transform(Lists.newArrayList(CmServerClusterInstance.getMounts(event.getClusterSpec(), event.getCluster())), new Function<String, String>() {
-              @Override
-              public String apply(String input) {
-                return input;
-              }
-            }))));
+        call(
+            "configure_cm_cdh",
+            "-r",
+            getRole(),
+            "-d",
+            Joiner.on(',').join(
+                Lists.transform(
+                    Lists.newArrayList(CmServerClusterInstance.getMounts(event.getClusterSpec(), event.getCluster())),
+                    new Function<String, String>() {
+                      @Override
+                      public String apply(String input) {
+                        return input;
+                      }
+                    }))));
   }
 
   @Override

--- a/src/main/java/com/cloudera/whirr/cm/handler/cdh/CmCdhSolrIndexerHBaseHandler.java
+++ b/src/main/java/com/cloudera/whirr/cm/handler/cdh/CmCdhSolrIndexerHBaseHandler.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to Cloudera, Inc. under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  Cloudera, Inc. licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.cloudera.whirr.cm.handler.cdh;
+
+import com.cloudera.whirr.cm.server.CmServerServiceType;
+
+public class CmCdhSolrIndexerHBaseHandler extends BaseHandlerCmCdh {
+
+  public static final String ROLE = "cm-cdh-solr-hbase-indexer";
+  public static final CmServerServiceType TYPE = CmServerServiceType.SOLR_INDEXER_HBASE;
+
+  @Override
+  public String getRole() {
+    return ROLE;
+  }
+
+  @Override
+  public CmServerServiceType getType() {
+    return TYPE;
+  }
+
+}

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServer.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServer.java
@@ -25,7 +25,7 @@ public interface CmServer {
   public String getVersion();
 
   public int getVersionApi();
-  
+
   public String getVersionCdh();
 
   public boolean getServiceConfigs(CmServerCluster cluster, File path) throws CmServerException;

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerBuilder.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerBuilder.java
@@ -132,7 +132,7 @@ public class CmServerBuilder implements CmServerConstants {
     this.server = null;
     return this;
   }
-  
+
   @CmServerCommandMethod(name = "ip")
   public CmServerBuilder ip(String ip) throws CmServerException {
     if (ip == null || ip.equals("")) {

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerCluster.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerCluster.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.commons.lang.StringUtils;
+
 public class CmServerCluster {
 
   private String name;
@@ -252,12 +254,14 @@ public class CmServerCluster {
     for (String configVersion : this.configuration.keySet()) {
       for (String configGroup : this.configuration.get(configVersion).keySet()) {
         for (String configSetting : this.configuration.get(configVersion).get(configGroup).keySet()) {
-          if (version < 0 || Integer.parseInt(configVersion) <= version) {
-            if (configuration.get(configGroup) == null) {
-              configuration.put(configGroup, new HashMap<String, String>());
+          if (StringUtils.isNumeric(configVersion)) {
+            if (version < 0 || Integer.parseInt(configVersion) <= version) {
+              if (configuration.get(configGroup) == null) {
+                configuration.put(configGroup, new HashMap<String, String>());
+              }
+              configuration.get(configGroup).put(configSetting,
+                  this.configuration.get(configVersion).get(configGroup).get(configSetting));
             }
-            configuration.get(configGroup).put(configSetting,
-                this.configuration.get(configVersion).get(configGroup).get(configSetting));
           }
         }
       }

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerServiceType.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerServiceType.java
@@ -58,6 +58,10 @@ public enum CmServerServiceType {
   SOLR(CLUSTER, "SOLR", 4, CmServerServiceTypeRepo.SOLR), SOLR_SERVER(SOLR, "SOLR_SERVER", 4,
       CmServerServiceTypeRepo.SOLR),
 
+  // Solr Indexers
+  SOLR_INDEXER(CLUSTER, "KS_INDEXER", 5, CmServerServiceTypeRepo.SOLR), SOLR_INDEXER_HBASE(SOLR_INDEXER,
+      "HBASE_INDEXER", 5, CmServerServiceTypeRepo.SOLR),
+
   // Sqoop
   SQOOP(CLUSTER, "SQOOP", 4, CmServerServiceTypeRepo.CDH), SQOOP_SERVER(SQOOP, "SQOOP_SERVER", 4,
       CmServerServiceTypeRepo.CDH),

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerServiceTypeCms.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerServiceTypeCms.java
@@ -42,7 +42,7 @@ public enum CmServerServiceTypeCms {
 
   // Reports Manager
   REPORTSMANAGER(MANAGEMENT, "REPORTSMANAGER", true),
-  
+
   // Navigator
   NAVIGATOR(MANAGEMENT, "NAVIGATOR", true);
 
@@ -63,7 +63,7 @@ public enum CmServerServiceTypeCms {
   public String getId() {
     return id;
   }
-  
+
   public boolean getEnterprise() {
     return enterprise;
   }

--- a/src/main/java/com/cloudera/whirr/cm/server/CmServerServiceTypeCms.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/CmServerServiceTypeCms.java
@@ -70,7 +70,7 @@ public enum CmServerServiceTypeCms {
 
   public String getName() {
     return MANAGEMENT.getId().toLowerCase()
-        + (getParent() != null ? (CmServerService.NAME_TOKEN_DELIM + getId().toLowerCase()) : "");
+        + (getParent() != null ? CmServerService.NAME_TOKEN_DELIM + getId().toLowerCase() : "");
   }
 
 }

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -1138,6 +1138,8 @@ public class CmServerImpl implements CmServer {
     case SOLR:
       if (versionApi >= 4) {
         execute(apiResourceRootV4.getClustersResource().getServicesResource(getName(cluster))
+            .initSolrCommand(cluster.getServiceName(CmServerServiceType.SOLR)));
+        execute(apiResourceRootV4.getClustersResource().getServicesResource(getName(cluster))
             .createSolrHdfsHomeDirCommand(cluster.getServiceName(CmServerServiceType.SOLR)));
       }
       break;

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -233,9 +233,8 @@ public class CmServerImpl implements CmServer {
                 .readServices(DataView.SUMMARY)) {
               CmServerServiceType type = CmServerServiceType.valueOfId(apiService.getType());
               if (type.equals(CmServerServiceType.HDFS) || type.equals(CmServerServiceType.MAPREDUCE)
-                  || type.equals(CmServerServiceType.HBASE) || (versionApi >= 4)
-                  && (type.equals(CmServerServiceType.HIVE)) || (versionApi >= 5)
-                  && (type.equals(CmServerServiceType.SOLR))) {
+                  || type.equals(CmServerServiceType.HBASE) || versionApi >= 4 && type.equals(CmServerServiceType.HIVE)
+                  || versionApi >= 5 && type.equals(CmServerServiceType.SOLR)) {
                 ZipInputStream configInputZip = null;
                 try {
                   InputStreamDataSource configInput = apiResourceRootV3.getClustersResource()
@@ -320,13 +319,13 @@ public class CmServerImpl implements CmServer {
     CmServerService serviceFound = null;
     try {
       for (CmServerService serviceTmp : services) {
-        if ((service.getHost() != null && service.getHost().equals(serviceTmp.getHost()))
-            || (service.getHost() != null && service.getHost().equals(serviceTmp.getIp()))
-            || (service.getHost() != null && service.getHost().equals(serviceTmp.getIpInternal()))
-            || (service.getIp() != null && service.getIp().equals(serviceTmp.getIp()))
-            || (service.getIp() != null && service.getIp().equals(serviceTmp.getIpInternal()))
-            || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIp()))
-            || (service.getIpInternal() != null && service.getIpInternal().equals(serviceTmp.getIpInternal()))) {
+        if (service.getHost() != null && service.getHost().equals(serviceTmp.getHost()) || service.getHost() != null
+            && service.getHost().equals(serviceTmp.getIp()) || service.getHost() != null
+            && service.getHost().equals(serviceTmp.getIpInternal()) || service.getIp() != null
+            && service.getIp().equals(serviceTmp.getIp()) || service.getIp() != null
+            && service.getIp().equals(serviceTmp.getIpInternal()) || service.getIpInternal() != null
+            && service.getIpInternal().equals(serviceTmp.getIp()) || service.getIpInternal() != null
+            && service.getIpInternal().equals(serviceTmp.getIpInternal())) {
           serviceFound = serviceTmp;
           break;
         }
@@ -546,7 +545,8 @@ public class CmServerImpl implements CmServer {
 
       logger.logOperationStartedSync("ClusterInitialise");
 
-      Map<String, String> configuration = cluster.getServiceConfiguration().get(CmServerServiceTypeCms.CM.getId());
+      Map<String, String> configuration = cluster.getServiceConfiguration(versionApi).get(
+          CmServerServiceTypeCms.CM.getId());
       configuration.remove("cm_database_name");
       configuration.remove("cm_database_type");
       executed = CmServerServiceTypeCms.CM.getId() != null
@@ -838,9 +838,9 @@ public class CmServerImpl implements CmServer {
                 if (!type.getEnterprise() || enterpriseDeployed) {
                   ApiRoleConfigGroup cmsRoleConfigGroupApiNew = new ApiRoleConfigGroup();
                   ApiServiceConfig cmsServiceConfigApi = new ApiServiceConfig();
-                  if (cluster.getServiceConfiguration().get(type.getId()) != null) {
-                    for (String setting : cluster.getServiceConfiguration().get(type.getId()).keySet()) {
-                      cmsServiceConfigApi.add(new ApiConfig(setting, cluster.getServiceConfiguration()
+                  if (cluster.getServiceConfiguration(versionApi).get(type.getId()) != null) {
+                    for (String setting : cluster.getServiceConfiguration(versionApi).get(type.getId()).keySet()) {
+                      cmsServiceConfigApi.add(new ApiConfig(setting, cluster.getServiceConfiguration(versionApi)
                           .get(type.getId()).get(setting)));
                     }
                   }
@@ -968,9 +968,9 @@ public class CmServerImpl implements CmServer {
           apiService.setName(cluster.getServiceName(type));
 
           ApiServiceConfig apiServiceConfig = new ApiServiceConfig();
-          if (cluster.getServiceConfiguration().get(type.getId()) != null) {
-            for (String setting : cluster.getServiceConfiguration().get(type.getId()).keySet()) {
-              apiServiceConfig.add(new ApiConfig(setting, cluster.getServiceConfiguration().get(type.getId())
+          if (cluster.getServiceConfiguration(versionApi).get(type.getId()) != null) {
+            for (String setting : cluster.getServiceConfiguration(versionApi).get(type.getId()).keySet()) {
+              apiServiceConfig.add(new ApiConfig(setting, cluster.getServiceConfiguration(versionApi).get(type.getId())
                   .get(setting)));
             }
           }
@@ -1065,7 +1065,7 @@ public class CmServerImpl implements CmServer {
               }
             }
             if (roleConfigGroupType != null) {
-              Map<String, String> config = cluster.getServiceConfiguration().get(roleConfigGroupType.getId());
+              Map<String, String> config = cluster.getServiceConfiguration(versionApi).get(roleConfigGroupType.getId());
               if (config != null) {
                 for (String setting : config.keySet()) {
                   apiConfigList.add(new ApiConfig(setting, config.get(setting)));

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerImpl.java
@@ -988,6 +988,10 @@ public class CmServerImpl implements CmServer {
             apiServiceConfig.add(new ApiConfig("zookeeper_service", cluster
                 .getServiceName(CmServerServiceType.ZOOKEEPER)));
             break;
+          case SOLR_INDEXER:
+            apiServiceConfig.add(new ApiConfig("hbase_service", cluster.getServiceName(CmServerServiceType.HBASE)));
+            apiServiceConfig.add(new ApiConfig("solr_service", cluster.getServiceName(CmServerServiceType.HBASE)));
+            break;
           case HUE:
             apiServiceConfig.add(new ApiConfig("hue_webhdfs", cluster.getServiceName(CmServerServiceType.HDFS_NAMENODE)));
             apiServiceConfig.add(new ApiConfig("hive_service", cluster.getServiceName(CmServerServiceType.HIVE)));

--- a/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerLog.java
+++ b/src/main/java/com/cloudera/whirr/cm/server/impl/CmServerLog.java
@@ -61,9 +61,9 @@ public abstract class CmServerLog {
 
   public void logOperation(String operation, String message) {
     if (!quiet) {
-      logMessage((operation == null ? "" : (tag == null ? "" : (tag + " ")))
-          + (operation == null || operation.equals("") ? "" : (((tag == null ? "" : "[") + operation
-              + (tag == null ? "" : "]") + " "))) + (message == null ? "" : message));
+      logMessage((operation == null ? "" : tag == null ? "" : tag + " ")
+          + (operation == null || operation.equals("") ? "" : (tag == null ? "" : "[") + operation
+              + (tag == null ? "" : "]") + " ") + (message == null ? "" : message));
     }
   }
 
@@ -73,9 +73,9 @@ public abstract class CmServerLog {
 
   public void logOperationIntermediate(String operation, String message) {
     if (!quiet) {
-      logMessageIntermediate((operation == null ? "" : (tag == null ? "" : (tag + " ")))
-          + (operation == null || operation.equals("") ? "" : (((tag == null ? "" : "[") + operation
-              + (tag == null ? "" : "]") + " "))) + (message == null ? "" : message));
+      logMessageIntermediate((operation == null ? "" : tag == null ? "" : tag + " ")
+          + (operation == null || operation.equals("") ? "" : (tag == null ? "" : "[") + operation
+              + (tag == null ? "" : "]") + " ") + (message == null ? "" : message));
     }
   }
 
@@ -233,7 +233,7 @@ public abstract class CmServerLog {
         failed = true;
         logOperation(operation, "Unexpected error executing command");
       }
-      logOperation(operation, (failed ? "failed" : "finished"));
+      logOperation(operation, failed ? "failed" : "finished");
     }
 
     @Override

--- a/src/main/resources/META-INF/services/org.apache.whirr.service.ClusterActionHandler
+++ b/src/main/resources/META-INF/services/org.apache.whirr.service.ClusterActionHandler
@@ -40,6 +40,8 @@ com.cloudera.whirr.cm.handler.cdh.CmCdhHBaseRegionServerHandler
 
 com.cloudera.whirr.cm.handler.cdh.CmCdhSolrServerHandler
 
+com.cloudera.whirr.cm.handler.cdh.CmCdhSolrIndexerHBaseHandler
+
 com.cloudera.whirr.cm.handler.cdh.CmCdhImpalaDaemonHandler
 com.cloudera.whirr.cm.handler.cdh.CmCdhImpalaStateStoreHandler
 

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -62,6 +62,7 @@ whirr.cm.default.config.hue_server.hue_server_log_dir=/hue/server/log
 whirr.cm.default.config.beeswax_server.beeswax_log_dir=/hue/beeswax/log
 
 whirr.cm.default.config.impalad.log_dir=/impala/daemon/log
+whirr.cm.default.config.5.impalad.audit_event_log_dir=/impala/daemon/audit
 whirr.cm.default.config.statestore.log_dir=/impala/statestore/log
 
 whirr.cm.default.config.oozie_server.oozie_data_dir=/oozie/data0

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -86,7 +86,7 @@ whirr.cm.default.config.navigator.mgmt_log_dir=/manager/navigator/log
 # CM Settings
 
 whirr.cm.config.cm.parcel_repo_path=/data0/manager/parcels/parcel-repository
-whirr.cm.config.cm.parcel_distribute_rate_limit_kbs_per_second=200000
+whirr.cm.config.cm.parcel_distribute_rate_limit_kbs_per_second=500000
 
 whirr.cm.config.hdfs.dfs_block_local_path_access_user=impala
 whirr.cm.config.datanode.dfs_datanode_data_dir_perm=755

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -101,6 +101,9 @@ whirr.cm.config.mapreduce_gateway.mapred_submit_replication=3
 whirr.cm.config.mapreduce_gateway.mapred_reduce_tasks=3
 whirr.cm.config.jobtracker.job_tracker_bind_wildcard=true
 
+whirr.cm.config.hbase.hbase_enable_replication=true
+whirr.cm.config.5.hbase.hbase_enable_indexing=true
+
 whirr.cm.config.oozie_server.oozie_web_console=true
 
 whirr.cm.config.cm.cm_database_type=

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -192,4 +192,3 @@ cm-cdh-hue-beeswaxserver.client.ports=
 cm-cdh-oozie-server.client.ports=11000
 
 cm-cdh-solr-server.client.ports=8983,8984
-

--- a/src/main/resources/whirr-cm-default.properties
+++ b/src/main/resources/whirr-cm-default.properties
@@ -86,7 +86,7 @@ whirr.cm.default.config.navigator.mgmt_log_dir=/manager/navigator/log
 # CM Settings
 
 whirr.cm.config.cm.parcel_repo_path=/data0/manager/parcels/parcel-repository
-whirr.cm.config.cm.parcel_distribute_rate_limit_kbs_per_second=100000
+whirr.cm.config.cm.parcel_distribute_rate_limit_kbs_per_second=200000
 
 whirr.cm.config.hdfs.dfs_block_local_path_access_user=impala
 whirr.cm.config.datanode.dfs_datanode_data_dir_perm=755

--- a/src/test/java/com/cloudera/whirr/cm/UtilsTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/UtilsTest.java
@@ -28,8 +28,8 @@ public class UtilsTest implements BaseTest {
   public void testUrlForURI() throws Exception {
     Assert.assertNull(Utils.urlForURI("classpath:///file-that-does-not-exist-we-hope"));
     Assert.assertNull(Utils.urlForURI("http://www.exmaple.com/non-existant-url"));
-    Assert.assertEquals(Utils.urlForURI("classpath:///whirr-cm-default.properties"), UtilsTest.class.getClassLoader()
-        .getResource("whirr-cm-default.properties"));
+    Assert.assertEquals(Utils.urlForURI("classpath:///" + CONFIG_WHIRR_DEFAULT_FILE), UtilsTest.class.getClassLoader()
+        .getResource(CONFIG_WHIRR_DEFAULT_FILE));
     File pom = new File("pom.xml");
     Assert.assertEquals(Utils.urlForURI("file://" + pom.getAbsolutePath()), pom.toURI().toURL());
   }

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmNodeHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmNodeHandlerTest.java
@@ -25,8 +25,6 @@ import java.util.Set;
 import org.apache.whirr.service.DryRunModule.DryRun;
 import org.junit.Test;
 
-import com.cloudera.whirr.cm.handler.CmNodeHandler;
-import com.cloudera.whirr.cm.handler.CmServerHandler;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableMap;

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmNodeHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmNodeHandlerTest.java
@@ -70,5 +70,5 @@ public class CmNodeHandlerTest extends BaseTestHandler {
         + CmNodeHandler.ROLE)));
     assertScriptPredicateOnPhase(dryRun, "bootstrap", bootstrapPredicate());
   }
-  
+
 }

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
@@ -116,7 +116,7 @@ public class CmServerHandlerTest extends BaseTestHandler {
         CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(Collections.<String, String> emptyMap()))
             .getString(CONFIG_WHIRR_INTERNAL_AGENT_LOG_FILE));
     Assert.assertEquals(
-        "100000",
+        "500000",
         configuration.getString(CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceTypeCms.CM.getId().toLowerCase()
             + ".parcel_distribute_rate_limit_kbs_per_second"));
 

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
@@ -230,14 +230,14 @@ public class CmServerHandlerTest extends BaseTestHandler {
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
             .get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
 
-    configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap
-        .of("whirr.instance-templates", "1 " + CmServerHandler.ROLE + ",2 " + CmNodeHandler.ROLE,
-            CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceTypeCms.CM.getId().toLowerCase() + "."
-                + CONFIG_CM_DB_SUFFIX_NAME, "cman", CONFIG_WHIRR_CM_CONFIG_PREFIX
-                + CmServerServiceTypeCms.CM.getId().toLowerCase() + "." + CONFIG_CM_DB_SUFFIX_TYPE, "postgres",
-            CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceType.HIVE.getId().toLowerCase() + ".hive_metastore_"
-                + CONFIG_CM_DB_SUFFIX_PORT, "9999", CONFIG_WHIRR_CM_LICENSE_URI,
-            "classpath:///whirr-cm-default.properties")));
+    configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap.of(
+        "whirr.instance-templates", "1 " + CmServerHandler.ROLE + ",2 " + CmNodeHandler.ROLE,
+        CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceTypeCms.CM.getId().toLowerCase() + "."
+            + CONFIG_CM_DB_SUFFIX_NAME, "cman", CONFIG_WHIRR_CM_CONFIG_PREFIX
+            + CmServerServiceTypeCms.CM.getId().toLowerCase() + "." + CONFIG_CM_DB_SUFFIX_TYPE, "postgres",
+        CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceType.HIVE.getId().toLowerCase() + ".hive_metastore_"
+            + CONFIG_CM_DB_SUFFIX_PORT, "9999", CONFIG_WHIRR_CM_LICENSE_URI, "classpath:///"
+            + CONFIG_WHIRR_DEFAULT_FILE)));
     Assert.assertEquals(
         "/data1"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
@@ -257,7 +257,7 @@ public class CmServerHandlerTest extends BaseTestHandler {
         "org.apache.hadoop.mapred.TaskTrackerCmonInst",
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
             .get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
-    Assert.assertEquals("classpath:///whirr-cm-default.properties",
+    Assert.assertEquals("classpath:///" + CONFIG_WHIRR_DEFAULT_FILE,
         configuration.getString(CONFIG_WHIRR_CM_LICENSE_URI));
 
     configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap.of(

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
@@ -50,6 +50,7 @@ import com.cloudera.whirr.cm.handler.cdh.CmCdhImpalaStateStoreHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhMapReduceJobTrackerHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhMapReduceTaskTrackerHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhOozieServerHandler;
+import com.cloudera.whirr.cm.handler.cdh.CmCdhSolrIndexerHBaseHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhSolrServerHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhSqoopServerHandler;
 import com.cloudera.whirr.cm.handler.cdh.CmCdhZookeeperServerHandler;
@@ -70,7 +71,8 @@ public class CmServerHandlerTest extends BaseTestHandler {
       CmCdhHdfsHttpFsHandler.ROLE };
   private static final String[] WHIRR_INSTANCE_TEMPLATE_ROLES_SLAVES = { CmCdhHdfsDataNodeHandler.ROLE,
       CmCdhMapReduceTaskTrackerHandler.ROLE, CmCdhZookeeperServerHandler.ROLE, CmCdhHBaseRegionServerHandler.ROLE,
-      CmCdhImpalaDaemonHandler.ROLE, CmCdhFlumeAgentHandler.ROLE, CmCdhHdfsHttpFsHandler.ROLE };
+      CmCdhImpalaDaemonHandler.ROLE, CmCdhFlumeAgentHandler.ROLE, CmCdhSolrIndexerHBaseHandler.ROLE,
+      CmCdhHdfsHttpFsHandler.ROLE };
   private static final int WHIRR_INSTANCE_TEMPLATE_NUM_ROLES = WHIRR_INSTANCE_TEMPLATE_ROLES_MASTER.length
       + WHIRR_INSTANCE_TEMPLATE_NUM_SLAVES * WHIRR_INSTANCE_TEMPLATE_ROLES_SLAVES.length;
   private static String WHIRR_INSTANCE_TEMPLATE_ALL = "1 " + CmServerHandler.ROLE + "+" + CmAgentHandler.ROLE + ",1 "

--- a/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/handler/CmServerHandlerTest.java
@@ -77,11 +77,11 @@ public class CmServerHandlerTest extends BaseTestHandler {
       + CmAgentHandler.ROLE;
   static {
     for (String role : WHIRR_INSTANCE_TEMPLATE_ROLES_MASTER) {
-      WHIRR_INSTANCE_TEMPLATE_ALL += ("+" + role);
+      WHIRR_INSTANCE_TEMPLATE_ALL += "+" + role;
     }
-    WHIRR_INSTANCE_TEMPLATE_ALL += ("," + WHIRR_INSTANCE_TEMPLATE_NUM_SLAVES + " " + CmAgentHandler.ROLE);
+    WHIRR_INSTANCE_TEMPLATE_ALL += "," + WHIRR_INSTANCE_TEMPLATE_NUM_SLAVES + " " + CmAgentHandler.ROLE;
     for (String role : WHIRR_INSTANCE_TEMPLATE_ROLES_SLAVES) {
-      WHIRR_INSTANCE_TEMPLATE_ALL += ("+" + role);
+      WHIRR_INSTANCE_TEMPLATE_ALL += "+" + role;
     }
   }
 
@@ -173,21 +173,24 @@ public class CmServerHandlerTest extends BaseTestHandler {
     Assert.assertEquals(
         configuration.getString(CONFIG_WHIRR_INTERNAL_DATA_DIRS_DEFAULT)
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
-                + CmServerServiceTypeCms.NAVIGATOR.getId().toLowerCase() + ".mgmt_log_dir"), CmServerClusterInstance
-            .getClusterConfiguration(configuration, new TreeSet<String>())
-            .get(CmServerServiceTypeCms.NAVIGATOR.getId()).get("mgmt_log_dir"));
+                + CmServerServiceTypeCms.NAVIGATOR.getId().toLowerCase() + ".mgmt_log_dir"),
+        CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceTypeCms.NAVIGATOR.getId())
+            .get("mgmt_log_dir"));
     Assert.assertEquals(
         configuration.getString(CONFIG_WHIRR_INTERNAL_DATA_DIRS_DEFAULT)
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         "/mnt/1"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1"))
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         "/mnt/1"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
@@ -197,10 +200,12 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertNull(CmServerClusterInstance
         .getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
-        .get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
+        .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId())
+        .get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
 
     configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap.of(
         "whirr.instance-templates", "1 " + CmServerHandler.ROLE + ",2 " + CmNodeHandler.ROLE,
@@ -215,7 +220,8 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceTypeCms.NAVIGATOR.getId().toLowerCase() + ".mgmt_log_dir"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/data1", "/data2"))
-            .get(CmServerServiceTypeCms.NAVIGATOR.getId()).get("mgmt_log_dir"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceTypeCms.NAVIGATOR.getId())
+            .get("mgmt_log_dir"));
     Assert.assertEquals(
         "/data1"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
@@ -224,11 +230,13 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/data1", "/data2"))
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         "org.apache.hadoop.mapred.TaskTrackerCmonInst",
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
-            .get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId())
+            .get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
 
     configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap.of(
         "whirr.instance-templates", "1 " + CmServerHandler.ROLE + ",2 " + CmNodeHandler.ROLE,
@@ -243,7 +251,8 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceTypeCms.NAVIGATOR.getId().toLowerCase() + ".mgmt_log_dir"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/data1", "/data2"))
-            .get(CmServerServiceTypeCms.NAVIGATOR.getId()).get("mgmt_log_dir"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceTypeCms.NAVIGATOR.getId())
+            .get("mgmt_log_dir"));
     Assert.assertEquals(
         "/data1"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
@@ -252,11 +261,13 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/data1", "/data2"))
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         "org.apache.hadoop.mapred.TaskTrackerCmonInst",
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
-            .get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId()).get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.MAPREDUCE_TASK_TRACKER.getId())
+            .get(CONFIG_CM_TASKTRACKER_INSTRUMENTATION));
     Assert.assertEquals("classpath:///" + CONFIG_WHIRR_DEFAULT_FILE,
         configuration.getString(CONFIG_WHIRR_CM_LICENSE_URI));
 
@@ -272,13 +283,15 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceTypeCms.NAVIGATOR.getId().toLowerCase() + ".mgmt_log_dir"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/tmp"))
-            .get(CmServerServiceTypeCms.NAVIGATOR.getId()).get("mgmt_log_dir"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceTypeCms.NAVIGATOR.getId())
+            .get("mgmt_log_dir"));
     Assert.assertEquals(
         "/tmp"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/tmp"))
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         "/mnt/1"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
@@ -287,7 +300,8 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals("postgres", CmServerClusterInstance.getClusterConfiguration(configuration,
         ImmutableSortedSet.of("/tmp"), CmServerServiceTypeCms.CM.getId(), null, CONFIG_CM_DB_SUFFIX_TYPE));
     Assert.assertEquals("mysql", CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>(),
@@ -312,36 +326,59 @@ public class CmServerHandlerTest extends BaseTestHandler {
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceTypeCms.NAVIGATOR.getId().toLowerCase() + ".mgmt_log_dir"),
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
-            .get(CmServerServiceTypeCms.NAVIGATOR.getId()).get("mgmt_log_dir"));
-    Assert.assertEquals("/mynn", CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
-        .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceTypeCms.NAVIGATOR.getId())
+            .get("mgmt_log_dir"));
+    Assert.assertEquals(
+        "/mynn",
+        CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         "/mynn",
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         configuration.getString(CONFIG_WHIRR_INTERNAL_DATA_DIRS_DEFAULT)
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_SECONDARY_NAMENODE.getId().toLowerCase() + ".fs_checkpoint_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
-            .get(CmServerServiceType.HDFS_SECONDARY_NAMENODE.getId()).get("fs_checkpoint_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_SECONDARY_NAMENODE.getId())
+            .get("fs_checkpoint_dir_list"));
 
     configuration = CmServerClusterInstance.getConfiguration(newClusterSpecForProperties(ImmutableMap.of(
         "whirr.instance-templates", "1 " + CmServerHandler.ROLE + ",2 " + CmNodeHandler.ROLE,
         CONFIG_WHIRR_CM_CONFIG_PREFIX + CmServerServiceType.HDFS_NAMENODE.getId().toLowerCase() + ".dfs_name_dir_list",
         "/mynn", CONFIG_WHIRR_DATA_DIRS_ROOT, "/tmp")));
-    Assert.assertEquals("/mynn", CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
-        .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+    Assert.assertEquals(
+        "/mynn",
+        CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         "/mynn",
         CmServerClusterInstance.getClusterConfiguration(configuration, ImmutableSortedSet.of("/mnt/1", "/mnt/2"))
-            .get(CmServerServiceType.HDFS_NAMENODE.getId()).get("dfs_name_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_NAMENODE.getId())
+            .get("dfs_name_dir_list"));
     Assert.assertEquals(
         "/data0"
             + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX
                 + CmServerServiceType.HDFS_SECONDARY_NAMENODE.getId().toLowerCase() + ".fs_checkpoint_dir_list"),
         CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
-            .get(CmServerServiceType.HDFS_SECONDARY_NAMENODE.getId()).get("fs_checkpoint_dir_list"));
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.HDFS_SECONDARY_NAMENODE.getId())
+            .get("fs_checkpoint_dir_list"));
+
+    Assert.assertEquals(
+        null,
+        CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>())
+            .get(CmServerClusterInstance.CM_API_BASE_VERSION).get(CmServerServiceType.IMPALA_DAEMON.getId())
+            .get("audit_event_log_dir"));
+    Assert.assertEquals(
+        "/data0"
+            + configuration.getString(CONFIG_WHIRR_INTERNAL_CM_CONFIG_DEFAULT_PREFIX + "5."
+                + CmServerServiceType.IMPALA_DAEMON.getId().toLowerCase() + ".audit_event_log_dir"),
+        CmServerClusterInstance.getClusterConfiguration(configuration, new TreeSet<String>()).get("5")
+            .get(CmServerServiceType.IMPALA_DAEMON.getId()).get("audit_event_log_dir"));
 
   }
 

--- a/src/test/java/com/cloudera/whirr/cm/integration/BaseITServer.java
+++ b/src/test/java/com/cloudera/whirr/cm/integration/BaseITServer.java
@@ -182,7 +182,7 @@ public abstract class BaseITServer implements BaseTest {
         + WordUtils.capitalize(System.getProperty(TEST_CM_API_VERSION))
         + WordUtils.capitalize(System.getProperty(TEST_CM_CDH_VERSION))
         + WordUtils.capitalize(System.getProperty(TEST_PLATFORM));
-    return WordUtils.capitalize(test.getMethodName()) + (qualifier.equals("") ? "" : ("-" + qualifier));
+    return WordUtils.capitalize(test.getMethodName()) + (qualifier.equals("") ? "" : "-" + qualifier);
   }
 
   protected boolean isClusterBootstrappedStatically() {

--- a/src/test/java/com/cloudera/whirr/cm/integration/CmServerClusterIT.java
+++ b/src/test/java/com/cloudera/whirr/cm/integration/CmServerClusterIT.java
@@ -128,7 +128,12 @@ public abstract class CmServerClusterIT extends BaseITServer {
     Assert.assertFalse(serverTest.isStarted(cluster));
     Assert.assertTrue(serverTest.isStopped(cluster));
 
-    // TODO: Test unprovision/provision once OPSAPS-14933 is addressed
+    Assert.assertTrue(serverTest.unprovision(cluster));
+
+    Assert.assertFalse(serverTest.isProvisioned(cluster));
+    Assert.assertFalse(serverTest.isConfigured(cluster));
+    Assert.assertFalse(serverTest.isStarted(cluster));
+    Assert.assertTrue(serverTest.isStopped(cluster));
 
   }
 

--- a/src/test/java/com/cloudera/whirr/cm/integration/CmServerCommandIT.java
+++ b/src/test/java/com/cloudera/whirr/cm/integration/CmServerCommandIT.java
@@ -10,6 +10,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.cloudera.whirr.cm.cmd.BaseCommandCmServer;
+import com.cloudera.whirr.cm.cmd.CmServerCleanClusterCommand;
 import com.cloudera.whirr.cm.cmd.CmServerCreateServicesCommand;
 import com.cloudera.whirr.cm.cmd.CmServerDestroyServicesCommand;
 import com.cloudera.whirr.cm.cmd.CmServerDownloadConfigCommand;
@@ -99,13 +100,12 @@ public class CmServerCommandIT extends CmServerClusterIT {
 
   @Test
   public void testCleanCluster() throws Exception {
-    // TODO: Re-enable once OPSAPS-14933 is addressed
-    // Assert.assertEquals(0, new CmServerCleanClusterCommand().run(specification, controller, OPTIONS_EMPTY));
-    // Assert.assertFalse(serverTestBootstrap.isProvisioned(cluster));
-    // Assert.assertFalse(serverTestBootstrap.isConfigured(cluster));
-    // Assert.assertFalse(serverTestBootstrap.isStarted(cluster));
-    // Assert.assertTrue(serverTestBootstrap.isStopped(cluster));
-    // Assert.assertEquals(0, serverTestBootstrap.getServices(cluster).getServiceTypes().size());
+    Assert.assertEquals(0, new CmServerCleanClusterCommand().run(specification, controller, OPTIONS_EMPTY));
+    Assert.assertFalse(serverTestBootstrap.isProvisioned(cluster));
+    Assert.assertFalse(serverTestBootstrap.isConfigured(cluster));
+    Assert.assertFalse(serverTestBootstrap.isStarted(cluster));
+    Assert.assertTrue(serverTestBootstrap.isStopped(cluster));
+    Assert.assertEquals(0, serverTestBootstrap.getServices(cluster).getServiceTypes().size());
   }
 
   @Test

--- a/src/test/java/com/cloudera/whirr/cm/integration/CmServerSmokeSuiteIT.java
+++ b/src/test/java/com/cloudera/whirr/cm/integration/CmServerSmokeSuiteIT.java
@@ -13,7 +13,7 @@ public class CmServerSmokeSuiteIT extends CmServerSmokeIT {
 
   private static String[] OS_VERSION_MATRIX = new String[] { "centos", "ubuntu" };
   private static String[][] CM_VERSION_MATRIX = new String[][] { { "cm4.5.0", "v3", "cdh4" },
-      { "cm4.6.0", "v3", "cdh4" }, { "cm4.6.0", "v4", "cdh4" }, { "", "", "" } };
+      { "cm4.6.0", "v3", "cdh4" }, { "cm4.6.0", "v4", "cdh4" }, { "cm4.7.0", "v4", "cdh4" }, { "", "", "" } };
 
   @Parameters
   public static Collection<String[]> data() {

--- a/src/test/java/com/cloudera/whirr/cm/server/CmServerClusterTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/CmServerClusterTest.java
@@ -124,7 +124,7 @@ public class CmServerClusterTest extends BaseTestServer {
         new CmServerFactory().getCmServer(null, "", "", 7180, "", "", null).getVersionApi());
     Assert.assertEquals(CmServerImpl.CM_VERSION_API_LATEST,
         new CmServerFactory().getCmServer("", "", "", 7180, "", "", null).getVersionApi());
-    Assert.assertEquals(4, new CmServerFactory().getCmServer("4", "", "", 7180, "", "", null).getVersionApi());
+    Assert.assertEquals(5, new CmServerFactory().getCmServer("4", "", "", 7180, "", "", null).getVersionApi());
     Assert.assertEquals(3, new CmServerFactory().getCmServer("4.5", "", "", 7180, "", "", null).getVersionApi());
     Assert.assertEquals(4, new CmServerFactory().getCmServer("4.6.0", "", "", 7180, "", "", null).getVersionApi());
     Assert.assertEquals(4, new CmServerFactory().getCmServer("4.6.2", "", "", 7180, "", "", null).getVersionApi());

--- a/src/test/java/com/cloudera/whirr/cm/server/CmServerClusterTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/CmServerClusterTest.java
@@ -220,6 +220,35 @@ public class CmServerClusterTest extends BaseTestServer {
   }
 
   @Test
+  public void testConfiguration() throws CmServerException {
+    CmServerCluster cluster = new CmServerCluster();
+    cluster.addServiceConfiguration("3", CmServerServiceType.HDFS_NAMENODE.getId(), "some-setting-3", "some-value-3");
+    cluster.addServiceConfiguration("4", CmServerServiceType.HDFS_NAMENODE.getId(), "some-setting-4", "some-value-4");
+    Assert
+        .assertEquals(
+            "some-value-3",
+            cluster.getServiceConfiguration().get("3").get(CmServerServiceType.HDFS_NAMENODE.getId())
+                .get("some-setting-3"));
+    Assert
+        .assertEquals(
+            "some-value-4",
+            cluster.getServiceConfiguration().get("4").get(CmServerServiceType.HDFS_NAMENODE.getId())
+                .get("some-setting-4"));
+    Assert.assertEquals("some-value-3",
+        cluster.getServiceConfiguration(3).get(CmServerServiceType.HDFS_NAMENODE.getId()).get("some-setting-3"));
+    Assert.assertEquals(null,
+        cluster.getServiceConfiguration(3).get(CmServerServiceType.HDFS_NAMENODE.getId()).get("some-setting-4"));
+    Assert.assertEquals("some-value-3",
+        cluster.getServiceConfiguration(4).get(CmServerServiceType.HDFS_NAMENODE.getId()).get("some-setting-3"));
+    Assert.assertEquals("some-value-4",
+        cluster.getServiceConfiguration(4).get(CmServerServiceType.HDFS_NAMENODE.getId()).get("some-setting-4"));
+    Assert.assertEquals("some-value-3",
+        cluster.getServiceConfiguration(10).get(CmServerServiceType.HDFS_NAMENODE.getId()).get("some-setting-3"));
+    Assert.assertEquals("some-value-4",
+        cluster.getServiceConfiguration(10).get(CmServerServiceType.HDFS_NAMENODE.getId()).get("some-setting-4"));
+  }
+
+  @Test
   public void testService() throws CmServerException {
     Assert.assertTrue(new CmServerServiceBuilder().type(CmServerServiceType.CLUSTER).build()
         .equals(new CmServerServiceBuilder().build()));

--- a/src/test/java/com/cloudera/whirr/cm/server/CmServerCommandTest.java
+++ b/src/test/java/com/cloudera/whirr/cm/server/CmServerCommandTest.java
@@ -41,15 +41,16 @@ public class CmServerCommandTest extends BaseTestServer {
 
   @Test
   public void testGetValid1() throws CmServerException {
-    Assert.assertNotNull(new CmServerBuilder().ip("host-1").cluster(cluster).path(TEST_DIR_CLIENT_CONFIG.getAbsolutePath())
-        .command("client"));
+    Assert.assertNotNull(new CmServerBuilder().ip("host-1").cluster(cluster)
+        .path(TEST_DIR_CLIENT_CONFIG.getAbsolutePath()).command("client"));
   }
 
   @Test
   public void testGetValid2() throws CmServerException {
-    Assert.assertNotNull(new CmServerBuilder().arguments(
-        new String[] { "--host", "host-1", "--client", TEST_DIR_CLIENT_CONFIG.getAbsolutePath(), "--command", "client" })
-        .cluster(cluster));
+    Assert.assertNotNull(new CmServerBuilder()
+        .arguments(
+            new String[] { "--host", "host-1", "--client", TEST_DIR_CLIENT_CONFIG.getAbsolutePath(), "--command",
+                "client" }).cluster(cluster));
   }
 
   @Test(expected = CmServerException.class)
@@ -104,13 +105,15 @@ public class CmServerCommandTest extends BaseTestServer {
 
   @Test(expected = CmServerException.class)
   public void testGetException11() throws CmServerException {
-    Assert.assertNotNull(new CmServerBuilder().ip("host-1").path(TEST_DIR_CLIENT_CONFIG.getAbsolutePath()).executeBoolean());
+    Assert.assertNotNull(new CmServerBuilder().ip("host-1").path(TEST_DIR_CLIENT_CONFIG.getAbsolutePath())
+        .executeBoolean());
   }
 
   @Test(expected = CmServerException.class)
   public void testGetException12() throws CmServerException {
     Assert.assertFalse(((Boolean) new CmServerBuilder()
-        .arguments(new String[] { "--host", "host-1", "--client", TEST_DIR_CLIENT_CONFIG.getAbsolutePath(), "--command" })
+        .arguments(
+            new String[] { "--host", "host-1", "--client", TEST_DIR_CLIENT_CONFIG.getAbsolutePath(), "--command" })
         .cluster(cluster).executeBoolean()).booleanValue());
   }
 

--- a/src/test/resources/test-whirrcm-centos.properties
+++ b/src/test/resources/test-whirrcm-centos.properties
@@ -18,8 +18,5 @@
 whirr.provider=aws-ec2
 whirr.hardware-id=m1.medium
 whirr.image-id=us-west-2/ami-e030a5d0
-whirr.location-id=us-west-2
-#whirr.image-id=eu-west-1/ami-8aa3a8fe
-#whirr.location-id=eu-west-1
+whirr.location-id=us-west-2c
 whirr.bootstrap-user=ec2-user
-

--- a/src/test/resources/test-whirrcm-centos.properties
+++ b/src/test/resources/test-whirrcm-centos.properties
@@ -16,7 +16,7 @@
 #
 
 whirr.provider=aws-ec2
-whirr.hardware-id=m1.medium
+whirr.hardware-id=m1.large
 whirr.image-id=us-west-2/ami-e030a5d0
 whirr.location-id=us-west-2c
 whirr.bootstrap-user=ec2-user

--- a/src/test/resources/test-whirrcm-example.properties
+++ b/src/test/resources/test-whirrcm-example.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-whirr.hardware-id=m1.medium
+whirr.hardware-id=m1.large

--- a/src/test/resources/test-whirrcm-ubuntu.properties
+++ b/src/test/resources/test-whirrcm-ubuntu.properties
@@ -18,6 +18,4 @@
 whirr.provider=aws-ec2
 whirr.hardware-id=m1.medium
 whirr.image-id=us-west-2/ami-fb68f8cb
-whirr.location-id=us-west-2
-#whirr.image-id=eu-west-1/ami-89b1a3fd
-#whirr.location-id=eu-west-1
+whirr.location-id=us-west-2c

--- a/src/test/resources/test-whirrcm-ubuntu.properties
+++ b/src/test/resources/test-whirrcm-ubuntu.properties
@@ -16,6 +16,6 @@
 #
 
 whirr.provider=aws-ec2
-whirr.hardware-id=m1.medium
+whirr.hardware-id=m1.large
 whirr.image-id=us-west-2/ami-fb68f8cb
 whirr.location-id=us-west-2c


### PR DESCRIPTION
Implement:
- Update example config for CM 4.7.0
- Upgrade CM API to V5
- Include Solr Hbase Indexer Service
- Implement CM API version aware configuration
- Improve Solr Service intialisation
- Update README with troubelshooting section
